### PR TITLE
Lateral stimuli test ecoute

### DIFF
--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -549,8 +549,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 121.638290405273438, 214.0, 70.0, 22.0 ],
-					"text" : "loadmess 1"
+					"patching_rect" : [ 149.0, 221.0, 70.0, 22.0 ],
+					"text" : "loadmess 0"
 				}
 
 			}
@@ -817,7 +817,7 @@
 							"version" : 1,
 							"isbank" : 0,
 							"isbase64" : 1,
-							"blob" : "862.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfHVMjLgjw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxLtXCNv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN4.CLv.yMxPyM4HCM3HxK9vCTAIUPMARZj0iHwgmHfXWXrUWY8HBLt.CL1.CLv.CMwjiMwXiM4jiLxHxK9vCTAIUPMARZj0iHwkmHfXWXrUWY8HBLt.yLx.CLv.iMzfCM4fSMyTiLh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOh.iKvDyLv.CLvDSLzPCMvjSL3HxK9vCTAIUPMARZj0iHx8FarIBH1EFa0UVOhzBLtXyL4jSN4LCN4XCM3PyL2TiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhzRLtPyMv.CLwHiLvbCLyDiL0HxK9vySSMzPu4lYocFHRU1XkklckIGTuIGc8HRKwHBHSUlajUlbIAUOhHBHSUlajUlbP8lbz0iHsDiHfLUYtQVYx8zTCEDYjIWYyMWOh7xTiUlakI0azEFcuI2Kh.xTk4FYkIWRtQWYxYWXr0iHw.CLh7hO77xTiUlakI0azEFcuImO.."
+							"blob" : "858.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfGVMjLgTw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBM03RLv.CLvXSLvLSMwTiMxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtXSL1.CLv.SM1HiM1bCNzbiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHv3hLyHCLv.SLwHSMyLSM1jyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iK1fSNv.CLwHSN1jSN2.yMh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLtLCLxjSN4jyMyHSN2DSL4DiHu3COPEjTA0DHoQVOhH2arwlHfXWXrUWY8HRK4PiK1XCLv.yL1XiLw.SNyfiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhDCLv3BN3.CLvPCN3HCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
 						}
 ,
 						"snapshotlist" : 						{
@@ -839,7 +839,7 @@
 										"version" : 1,
 										"isbank" : 0,
 										"isbase64" : 1,
-										"blob" : "862.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfHVMjLgjw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxLtXCNv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN4.CLv.yMxPyM4HCM3HxK9vCTAIUPMARZj0iHwgmHfXWXrUWY8HBLt.CL1.CLv.CMwjiMwXiM4jiLxHxK9vCTAIUPMARZj0iHwkmHfXWXrUWY8HBLt.yLx.CLv.iMzfCM4fSMyTiLh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOh.iKvDyLv.CLvDSLzPCMvjSL3HxK9vCTAIUPMARZj0iHx8FarIBH1EFa0UVOhzBLtXyL4jSN4LCN4XCM3PyL2TiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhzRLtPyMv.CLwHiLvbCLyDiL0HxK9vySSMzPu4lYocFHRU1XkklckIGTuIGc8HRKwHBHSUlajUlbIAUOhHBHSUlajUlbP8lbz0iHsDiHfLUYtQVYx8zTCEDYjIWYyMWOh7xTiUlakI0azEFcuI2Kh.xTk4FYkIWRtQWYxYWXr0iHw.CLh7hO77xTiUlakI0azEFcuImO.."
+										"blob" : "858.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfGVMjLgTw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBM03RLv.CLvXSLvLSMwTiMxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtXSL1.CLv.SM1HiM1bCNzbiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHv3hLyHCLv.SLwHSMyLSM1jyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iK1fSNv.CLwHSN1jSN2.yMh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLtLCLxjSN4jyMyHSN2DSL4DiHu3COPEjTA0DHoQVOhH2arwlHfXWXrUWY8HRK4PiK1XCLv.yL1XiLw.SNyfiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhDCLv3BN3.CLvPCN3HCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
 									}
 ,
 									"fileref" : 									{
@@ -869,7 +869,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 168.0, 347.0, 61.0, 22.0 ],
+					"patching_rect" : [ 169.0, 348.404266357421875, 61.0, 22.0 ],
 					"text" : "delay 100"
 				}
 
@@ -2035,7 +2035,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 315.0, 36.322208404541016, 30.0, 37.0 ],
 					"text" : "A",
-					"textcolor" : [ 0.635, 0.482, 0.361, 1.0 ],
+					"textcolor" : [ 0.173, 0.212, 0.224, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -3334,13 +3334,12 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-4",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 11,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 237.0, 555.0, 337.0, 36.0 ],
-					"text" : "combine quartet _ broadcastingstudio _ Extremal _ 64 _ 6cm _o7 _90.wav @padding 0 0 0 0 0 0 4 0 0 0"
+					"patching_rect" : [ 237.0, 555.0, 537.0, 22.0 ],
+					"text" : "combine quartet _ broadcastingstudio _ Extremal _ 64 _ 6cm _o7 _90 @padding 0 0 0 0 0 0 4 0 0 0"
 				}
 
 			}
@@ -3975,7 +3974,6 @@
 					"numinlets" : 0,
 					"numoutlets" : 0,
 					"patching_rect" : [ 1140.0, 540.0, 150.0, 34.0 ],
-					"presentation_linecount" : 2,
 					"suppressinlet" : 1,
 					"text" : "Envoi vers SceneRotator:\nW X Y Z"
 				}
@@ -4026,7 +4024,6 @@
 					"numinlets" : 0,
 					"numoutlets" : 0,
 					"patching_rect" : [ 1140.0, 300.0, 135.0, 34.0 ],
-					"presentation_linecount" : 2,
 					"suppressinlet" : 1,
 					"text" : "Sortie du HeadTracker:\nW X Y Z"
 				}
@@ -4059,7 +4056,6 @@
 					"numinlets" : 0,
 					"numoutlets" : 0,
 					"patching_rect" : [ 1440.0, 440.0, 180.0, 75.0 ],
-					"presentation_linecount" : 5,
 					"suppressinlet" : 1,
 					"text" : "Qoffset = Q0* \n(Q0: rotation de l'origine du repère à l'origine souhaitée)\n\n=> Qtot = Qoffset * QheadTrack"
 				}
@@ -5824,7 +5820,48 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-31", 0 ],
+					"order" : 0,
+					"source" : [ "obj-92", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-43", 0 ],
+					"order" : 1,
+					"source" : [ "obj-92", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
+					"order" : 5,
+					"source" : [ "obj-92", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-6", 0 ],
+					"order" : 4,
+					"source" : [ "obj-92", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-7", 0 ],
+					"order" : 3,
+					"source" : [ "obj-92", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"order" : 2,
 					"source" : [ "obj-92", 0 ]
 				}
 

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 1954.0, 81.0, 842.0, 883.0 ],
+		"rect" : [ 1954.0, 81.0, 1212.0, 883.0 ],
 		"bglocked" : 1,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -39,6 +39,42 @@
 		"subpatcher_template" : "ManipAliasingSpatial",
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-350",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 150.0, 1665.0, 84.0, 22.0 ],
+					"text" : "s readyToPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-349",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "bang" ],
+					"patching_rect" : [ 150.0, 1638.3333740234375, 32.0, 22.0 ],
+					"text" : "t 1 b"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-348",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "bang" ],
+					"patching_rect" : [ 65.5, 1340.6666259765625, 32.0, 22.0 ],
+					"text" : "t 0 b"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
 					"id" : "obj-347",
@@ -609,7 +645,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 145.5, 1241.6666259765625, 82.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1230.0, 82.0, 22.0 ],
 					"text" : "r readyToPlay"
 				}
 
@@ -621,7 +657,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 145.5, 1274.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1263.0, 32.0, 22.0 ],
 					"text" : "gate"
 				}
 
@@ -781,7 +817,7 @@
 							"version" : 1,
 							"isbank" : 0,
 							"isbase64" : 1,
-							"blob" : "849.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LPEVMjLgvv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBLtHSLv.CL1bSLyfiM2DCN2TiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKv.SNv.CLvXiL4PiL0.CM3fyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iKv.iLv.CLvjyLzXCLvfyLv.CNh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLt.SL3jSN4jyLzDSN1PyMxDyMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsDiKvPCLv.CN0PCM4HSL3bSMh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HhLtDyM4jSNxXyM0bCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
+							"blob" : "862.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfHVMjLgjw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxLtXCNv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN4.CLv.yMxPyM4HCM3HxK9vCTAIUPMARZj0iHwgmHfXWXrUWY8HBLt.CL1.CLv.CMwjiMwXiM4jiLxHxK9vCTAIUPMARZj0iHwkmHfXWXrUWY8HBLt.yLx.CLv.iMzfCM4fSMyTiLh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOh.iKvDyLv.CLvDSLzPCMvjSL3HxK9vCTAIUPMARZj0iHx8FarIBH1EFa0UVOhzBLtXyL4jSN4LCN4XCM3PyL2TiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhzRLtPyMv.CLwHiLvbCLyDiL0HxK9vySSMzPu4lYocFHRU1XkklckIGTuIGc8HRKwHBHSUlajUlbIAUOhHBHSUlajUlbP8lbz0iHsDiHfLUYtQVYx8zTCEDYjIWYyMWOh7xTiUlakI0azEFcuI2Kh.xTk4FYkIWRtQWYxYWXr0iHw.CLh7hO77xTiUlakI0azEFcuImO.."
 						}
 ,
 						"snapshotlist" : 						{
@@ -803,7 +839,7 @@
 										"version" : 1,
 										"isbank" : 0,
 										"isbase64" : 1,
-										"blob" : "849.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LPEVMjLgvv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBLtHSLv.CL1bSLyfiM2DCN2TiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKv.SNv.CLvXiL4PiL0.CM3fyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iKv.iLv.CLvjyLzXCLvfyLv.CNh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLt.SL3jSN4jyLzDSN1PyMxDyMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsDiKvPCLv.CN0PCM4HSL3bSMh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HhLtDyM4jSNxXyM0bCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
+										"blob" : "862.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfHVMjLgjw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxLtXCNv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN4.CLv.yMxPyM4HCM3HxK9vCTAIUPMARZj0iHwgmHfXWXrUWY8HBLt.CL1.CLv.CMwjiMwXiM4jiLxHxK9vCTAIUPMARZj0iHwkmHfXWXrUWY8HBLt.yLx.CLv.iMzfCM4fSMyTiLh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOh.iKvDyLv.CLvDSLzPCMvjSL3HxK9vCTAIUPMARZj0iHx8FarIBH1EFa0UVOhzBLtXyL4jSN4LCN4XCM3PyL2TiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhzRLtPyMv.CLwHiLvbCLyDiL0HxK9vySSMzPu4lYocFHRU1XkklckIGTuIGc8HRKwHBHSUlajUlbIAUOhHBHSUlajUlbP8lbz0iHsDiHfLUYtQVYx8zTCEDYjIWYyMWOh7xTiUlakI0azEFcuI2Kh.xTk4FYkIWRtQWYxYWXr0iHw.CLh7hO77xTiUlakI0azEFcuImO.."
 									}
 ,
 									"fileref" : 									{
@@ -1999,7 +2035,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 315.0, 36.322208404541016, 30.0, 37.0 ],
 					"text" : "A",
-					"textcolor" : [ 0.173, 0.212, 0.224, 1.0 ],
+					"textcolor" : [ 0.635, 0.482, 0.361, 1.0 ],
 					"textjustification" : 1
 				}
 
@@ -2011,7 +2047,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1301.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1290.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2035,7 +2071,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 9,
 					"outlettype" : [ "float", "list", "float", "float", "float", "float", "float", "", "int" ],
-					"patching_rect" : [ 257.5, 1332.6666259765625, 103.0, 22.0 ],
+					"patching_rect" : [ 262.0, 1321.0, 103.0, 22.0 ],
 					"text" : "info~ buff.1"
 				}
 
@@ -2047,7 +2083,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1527.6666259765625, 51.0, 22.0 ],
+					"patching_rect" : [ 189.5, 1516.0, 51.0, 22.0 ],
 					"text" : "s pause"
 				}
 
@@ -2059,7 +2095,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1527.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1516.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2071,7 +2107,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1403.6666259765625, 51.0, 22.0 ],
+					"patching_rect" : [ 189.5, 1392.0, 51.0, 22.0 ],
 					"text" : "s pause"
 				}
 
@@ -2083,7 +2119,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1403.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1392.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2094,7 +2130,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1625.6666259765625, 74.0, 20.0 ],
+					"patching_rect" : [ 189.5, 1614.0, 74.0, 20.0 ],
 					"text" : "X is playing"
 				}
 
@@ -2107,7 +2143,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 265.5, 1263.6666259765625, 81.0, 22.0 ],
+					"patching_rect" : [ 270.0, 1252.0, 81.0, 22.0 ],
 					"text" : "r dureePause"
 				}
 
@@ -2132,7 +2168,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 145.5, 1650.6666259765625, 61.0, 22.0 ],
+					"patching_rect" : [ 253.029541015625, 1665.0, 61.0, 22.0 ],
 					"text" : "s endPlay"
 				}
 
@@ -2144,7 +2180,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 145.5, 1625.6666259765625, 37.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1614.0, 37.0, 22.0 ],
 					"text" : "delay"
 				}
 
@@ -2156,7 +2192,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1596.6666259765625, 48.0, 22.0 ],
+					"patching_rect" : [ 189.5, 1585.0, 48.0, 22.0 ],
 					"text" : "s playX"
 				}
 
@@ -2168,7 +2204,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1596.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1585.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2179,7 +2215,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1557.6666259765625, 48.0, 20.0 ],
+					"patching_rect" : [ 189.5, 1546.0, 48.0, 20.0 ],
 					"text" : "pause"
 				}
 
@@ -2190,7 +2226,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1498.6666259765625, 74.0, 20.0 ],
+					"patching_rect" : [ 189.5, 1487.0, 74.0, 20.0 ],
 					"text" : "B is playing"
 				}
 
@@ -2202,7 +2238,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 145.5, 1557.6666259765625, 37.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1546.0, 37.0, 22.0 ],
 					"text" : "delay"
 				}
 
@@ -2214,7 +2250,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 145.5, 1498.6666259765625, 37.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1487.0, 37.0, 22.0 ],
 					"text" : "delay"
 				}
 
@@ -2226,7 +2262,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1469.6666259765625, 48.0, 22.0 ],
+					"patching_rect" : [ 189.5, 1458.0, 48.0, 22.0 ],
 					"text" : "s playB"
 				}
 
@@ -2238,7 +2274,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1469.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1458.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2249,7 +2285,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1435.6666259765625, 48.0, 20.0 ],
+					"patching_rect" : [ 189.5, 1424.0, 48.0, 20.0 ],
 					"text" : "pause"
 				}
 
@@ -2261,7 +2297,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 145.5, 1435.6666259765625, 37.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1424.0, 37.0, 22.0 ],
 					"text" : "delay"
 				}
 
@@ -2272,7 +2308,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1373.6666259765625, 74.0, 20.0 ],
+					"patching_rect" : [ 189.5, 1362.0, 74.0, 20.0 ],
 					"text" : "A is playing"
 				}
 
@@ -2284,7 +2320,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 185.0, 1332.6666259765625, 48.0, 22.0 ],
+					"patching_rect" : [ 189.5, 1321.0, 48.0, 22.0 ],
 					"text" : "s playA"
 				}
 
@@ -2296,7 +2332,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 145.5, 1373.6666259765625, 37.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1362.0, 37.0, 22.0 ],
 					"text" : "delay"
 				}
 
@@ -2308,7 +2344,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 145.5, 1332.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 150.0, 1321.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -5059,7 +5095,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-119", 1 ],
+					"destination" : [ "obj-348", 0 ],
 					"source" : [ "obj-259", 0 ]
 				}
 
@@ -5380,6 +5416,34 @@
 				"patchline" : 				{
 					"destination" : [ "obj-70", 0 ],
 					"source" : [ "obj-33", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-119", 1 ],
+					"source" : [ "obj-348", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-119", 0 ],
+					"source" : [ "obj-348", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-111", 0 ],
+					"source" : [ "obj-349", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-350", 0 ],
+					"source" : [ "obj-349", 0 ]
 				}
 
 			}
@@ -5774,7 +5838,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-111", 0 ],
+					"destination" : [ "obj-349", 0 ],
 					"source" : [ "obj-94", 0 ]
 				}
 

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 1954.0, 81.0, 1212.0, 883.0 ],
+		"rect" : [ 1954.0, 81.0, 842.0, 883.0 ],
 		"bglocked" : 1,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -41,36 +41,470 @@
 		"boxes" : [ 			{
 				"box" : 				{
 					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-350",
+					"id" : "obj-323",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 150.0, 1665.0, 84.0, 22.0 ],
+					"patching_rect" : [ 289.0, 1650.0, 84.0, 22.0 ],
 					"text" : "s readyToPlay"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-349",
+					"id" : "obj-321",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "int", "bang" ],
-					"patching_rect" : [ 150.0, 1638.3333740234375, 32.0, 22.0 ],
+					"patching_rect" : [ 289.0, 1560.0, 32.0, 22.0 ],
 					"text" : "t 1 b"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-348",
+					"bgcolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
+					"blinkcolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ],
+					"id" : "obj-290",
+					"maxclass" : "button",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"outlinecolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 144.0, 1260.0, 24.0, 24.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 147.5, 1757.6666259765625, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-289",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 324.0, 1260.0, 96.0, 22.0 ],
+					"text" : "r filesAreLoaded"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-32",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 200.0, 1344.0, 133.0, 34.0 ],
+					"text" : "Change number of commands here"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-66",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 655.5, 1348.0, 110.0, 34.0 ],
+					"text" : "Modify commands here"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-86",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 302.0, 1611.5, 105.0, 34.0 ],
+					"text" : "last stimulus causes endPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-121",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "int", "int", "int" ],
+					"patching_rect" : [ 131.0, 1316.0, 42.0, 22.0 ],
+					"text" : "t 1 1 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-123",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 609.0, 1396.0, 48.0, 22.0 ],
+					"text" : "s playX"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-124",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 609.0, 1372.0, 48.0, 22.0 ],
+					"text" : "s playB"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-139",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 609.0, 1348.0, 48.0, 22.0 ],
+					"text" : "s playA"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-143",
+					"maxclass" : "newobj",
+					"numinlets" : 4,
+					"numoutlets" : 4,
+					"outlettype" : [ "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 609.0, 1316.0, 54.0, 22.0 ],
+					"text" : "sel 1 2 3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-160",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 609.0, 1290.0, 62.0, 22.0 ],
+					"text" : "r playStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-166",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 118.0, 1410.0, 42.0, 22.0 ],
+					"text" : "gate 2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-173",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 164.333328247070312, 1380.0, 29.5, 22.0 ],
+					"text" : "+ 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-185",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 118.0, 1650.5, 65.0, 22.0 ],
+					"text" : "s nextStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-186",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 136.0, 1599.0, 81.0, 22.0 ],
+					"text" : "r dureePause"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-192",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 118.0, 1623.0, 37.0, 22.0 ],
+					"text" : "delay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-203",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 131.0, 1575.0, 51.0, 22.0 ],
+					"text" : "s pause"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-206",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "int", "bang" ],
-					"patching_rect" : [ 65.5, 1340.6666259765625, 32.0, 22.0 ],
-					"text" : "t 0 b"
+					"outlettype" : [ "bang", "bang" ],
+					"patching_rect" : [ 118.0, 1541.5, 32.0, 22.0 ],
+					"text" : "t b b"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-209",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 23.0, 1305.0, 63.0, 22.0 ],
+					"text" : "r nextStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-212",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 128.5, 1470.0, 64.0, 22.0 ],
+					"text" : "s playStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-216",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 136.0, 1494.0, 70.0, 22.0 ],
+					"text" : "r dureePlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-220",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 118.0, 1515.0, 37.0, 22.0 ],
+					"text" : "delay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-221",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "int" ],
+					"patching_rect" : [ 118.0, 1436.5, 29.5, 22.0 ],
+					"text" : "t b i"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-223",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 302.0, 1590.0, 61.0, 22.0 ],
+					"text" : "s endPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-248",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 387.0, 1353.0, 72.0, 22.0 ],
+					"text" : "s dureePlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-249",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 307.0, 1494.5, 70.0, 22.0 ],
+					"text" : "r dureePlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-258",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 289.0, 1524.5, 37.0, 22.0 ],
+					"text" : "delay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-264",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 302.0, 1464.5, 64.0, 22.0 ],
+					"text" : "s playStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-266",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "int" ],
+					"patching_rect" : [ 289.0, 1436.5, 29.5, 22.0 ],
+					"text" : "t b i"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-270",
+					"maxclass" : "newobj",
+					"numinlets" : 5,
+					"numoutlets" : 4,
+					"outlettype" : [ "int", "", "", "int" ],
+					"patching_rect" : [ 130.999994913736941, 1350.0, 69.0, 22.0 ],
+					"text" : "counter 1 3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-272",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 387.0, 1323.0, 57.0, 22.0 ],
+					"text" : "minimum"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-274",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 9,
+					"outlettype" : [ "float", "list", "float", "float", "float", "float", "float", "", "int" ],
+					"patching_rect" : [ 324.0, 1290.0, 103.0, 22.0 ],
+					"text" : "info~ buff.1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-275",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 131.0, 1290.0, 32.0, 22.0 ],
+					"text" : "gate"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-279",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 42.0, 1260.0, 82.0, 22.0 ],
+					"text" : "r readyToPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-280",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 438.0, 1290.0, 71.0, 22.0 ],
+					"text" : "r dureeStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-281",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 144.0, 1230.0, 38.0, 22.0 ],
+					"text" : "r play"
 				}
 
 			}
@@ -81,7 +515,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1305.0, 840.0, 76.0, 22.0 ],
+					"patching_rect" : [ 786.071428571428555, 1065.0, 76.0, 22.0 ],
 					"text" : "s resetOffset"
 				}
 
@@ -107,7 +541,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1350.0, 405.0, 74.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 850.384620428085327, 74.0, 22.0 ],
 					"text" : "r resetOffset"
 				}
 
@@ -119,7 +553,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1395.5, 563.5, 113.0, 22.0 ],
+					"patching_rect" : [ 1305.5, 1008.884620428085327, 113.0, 22.0 ],
 					"text" : "loadmess 0. 0. 0. 1."
 				}
 
@@ -131,7 +565,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "" ],
-					"patching_rect" : [ 1540.5, 569.5, 29.5, 22.0 ],
+					"patching_rect" : [ 1450.5, 1014.884620428085327, 29.5, 22.0 ],
 					"text" : "t b l"
 				}
 
@@ -144,7 +578,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1350.0, 613.5, 54.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 1058.884620428085327, 54.0, 22.0 ],
 					"text" : "pv offset"
 				}
 
@@ -156,7 +590,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1350.0, 684.0, 91.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 1129.384620428085327, 91.0, 22.0 ],
 					"text" : "s centeredQuat"
 				}
 
@@ -169,7 +603,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1540.5, 539.5, 72.0, 22.0 ],
+					"patching_rect" : [ 1450.5, 984.884620428085327, 72.0, 22.0 ],
 					"text" : "r headTrack"
 				}
 
@@ -181,7 +615,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 1375.0, 534.0, 78.0, 22.0 ],
+					"patching_rect" : [ 1285.0, 979.384620428085327, 78.0, 22.0 ],
 					"text" : "route inverse"
 				}
 
@@ -193,7 +627,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "list", "" ],
-					"patching_rect" : [ 1350.0, 501.5, 44.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 946.884620428085327, 44.0, 22.0 ],
 					"text" : "jit.quat"
 				}
 
@@ -205,7 +639,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 1350.0, 473.5, 77.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 918.884620428085327, 77.0, 22.0 ],
 					"text" : "t getinverse l"
 				}
 
@@ -217,7 +651,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "list", "" ],
-					"patching_rect" : [ 1350.0, 649.5, 220.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 1094.884620428085327, 220.0, 22.0 ],
 					"text" : "jit.quat @quat2 0. 0. 0. 1. @normalize 0"
 				}
 
@@ -230,7 +664,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1427.658536672592163, 405.0, 72.0, 22.0 ],
+					"patching_rect" : [ 1337.658536672592163, 850.384620428085327, 72.0, 22.0 ],
 					"text" : "r headTrack"
 				}
 
@@ -242,7 +676,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1350.0, 444.0, 31.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 889.384620428085327, 31.0, 22.0 ],
 					"text" : "pv q"
 				}
 
@@ -255,7 +689,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 1350.0, 334.615379571914673, 24.0, 24.0 ]
+					"patching_rect" : [ 1260.0, 780.0, 24.0, 24.0 ]
 				}
 
 			}
@@ -266,7 +700,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1350.0, 364.615379571914673, 76.0, 22.0 ],
+					"patching_rect" : [ 1260.0, 810.0, 76.0, 22.0 ],
 					"text" : "s resetOffset"
 				}
 
@@ -278,7 +712,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1145.0, 369.615379571914673, 77.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 804.615379571914673, 77.0, 22.0 ],
 					"text" : "prepend port"
 				}
 
@@ -291,7 +725,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1145.0, 336.615379571914673, 58.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 771.615379571914673, 58.0, 22.0 ],
 					"text" : "r udpPort"
 				}
 
@@ -303,7 +737,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1145.0, 459.615379571914673, 72.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 894.615379571914673, 72.0, 22.0 ],
 					"text" : "$2 $3 $4 $1"
 				}
 
@@ -315,7 +749,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1151.5, 690.0, 95.0, 22.0 ],
+					"patching_rect" : [ 1061.5, 1149.0, 95.0, 22.0 ],
 					"text" : "s sceneRotation"
 				}
 
@@ -328,7 +762,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1151.5, 576.0, 89.0, 22.0 ],
+					"patching_rect" : [ 1061.5, 1035.0, 89.0, 22.0 ],
 					"text" : "r centeredQuat"
 				}
 
@@ -340,7 +774,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1151.5, 605.5, 106.0, 22.0 ],
+					"patching_rect" : [ 1061.5, 1064.5, 106.0, 22.0 ],
 					"text" : "vexpr ($f1 + 1) / 2."
 				}
 
@@ -352,7 +786,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 1151.5, 661.317073345184326, 61.0, 22.0 ],
+					"patching_rect" : [ 1061.5, 1120.317073345184326, 61.0, 22.0 ],
 					"text" : "zl.group 2"
 				}
 
@@ -364,7 +798,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1151.5, 633.780488967895508, 112.0, 22.0 ],
+					"patching_rect" : [ 1061.5, 1092.780488967895508, 112.0, 22.0 ],
 					"text" : "6 $4 7 $1 8 $2 9 $3"
 				}
 
@@ -376,7 +810,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1145.0, 497.0, 74.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 932.0, 74.0, 22.0 ],
 					"text" : "s headTrack"
 				}
 
@@ -387,7 +821,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1221.0, 459.615379571914673, 101.0, 20.0 ],
+					"patching_rect" : [ 1131.0, 894.615379571914673, 101.0, 20.0 ],
 					"text" : "jit.quat: X Y Z W"
 				}
 
@@ -399,7 +833,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 1145.0, 423.615379571914673, 102.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 858.615379571914673, 102.0, 22.0 ],
 					"text" : "route /Quaternion"
 				}
 
@@ -411,7 +845,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1145.0, 396.0, 97.0, 22.0 ],
+					"patching_rect" : [ 1055.0, 831.0, 97.0, 22.0 ],
 					"text" : "udpreceive 4040"
 				}
 
@@ -632,33 +1066,8 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1295.0, 876.0, 80.0, 22.0 ],
+					"patching_rect" : [ 769.64285714285711, 1095.0, 80.0, 22.0 ],
 					"text" : "s chargeFiles"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-120",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 150.0, 1230.0, 82.0, 22.0 ],
-					"text" : "r readyToPlay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-119",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 150.0, 1263.0, 32.0, 22.0 ],
-					"text" : "gate"
 				}
 
 			}
@@ -669,7 +1078,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 536.5, 1437.6666259765625, 84.0, 22.0 ],
+					"patching_rect" : [ 895.0, 1425.553571432828903, 84.0, 22.0 ],
 					"text" : "s readyToPlay"
 				}
 
@@ -682,7 +1091,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 681.0, 1488.0, 24.0, 24.0 ]
+					"patching_rect" : [ 1039.5, 1475.886945456266403, 24.0, 24.0 ]
 				}
 
 			}
@@ -817,7 +1226,7 @@
 							"version" : 1,
 							"isbank" : 0,
 							"isbase64" : 1,
-							"blob" : "858.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfGVMjLgTw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBM03RLv.CLvXSLvLSMwTiMxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtXSL1.CLv.SM1HiM1bCNzbiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHv3hLyHCLv.SLwHSMyLSM1jyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iK1fSNv.CLwHSN1jSN2.yMh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLtLCLxjSN4jyMyHSN2DSL4DiHu3COPEjTA0DHoQVOhH2arwlHfXWXrUWY8HRK4PiK1XCLv.yL1XiLw.SNyfiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhDCLv3BN3.CLvPCN3HCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
+							"blob" : "860.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.HVMjLgbw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzRNtjyLv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN0.CLvDiLyjyM2XiMwDiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHs.iKvDCM4jSN4HiMvjCLxPCLzfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL3XCLv.CL3PCN2bCLwPSL1HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HRKv3BLzHSN4jSN3HCNyLCN1HyLh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHw3xLvjSN4bSM0fSM4LyM0HxK9vCTAIUPMARZj0iHx8FcgQWZu41TkEWck41XkIBH1EFa0UVOhDiKvHxK9vCTAIUPMARZj0iH0MWYS4zLDIBH1EFa0UVOhDiKvHxK9vCTAIUPMARZj0iH4E1ch.hcgwVck0iHz3BNyjSN4XyLybCN4.iMxTiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
 						}
 ,
 						"snapshotlist" : 						{
@@ -839,7 +1248,7 @@
 										"version" : 1,
 										"isbank" : 0,
 										"isbase64" : 1,
-										"blob" : "858.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LfGVMjLgTw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBM03RLv.CLvXSLvLSMwTiMxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtXSL1.CLv.SM1HiM1bCNzbiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHv3hLyHCLv.SLwHSMyLSM1jyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iK1fSNv.CLwHSN1jSN2.yMh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLtLCLxjSN4jyMyHSN2DSL4DiHu3COPEjTA0DHoQVOhH2arwlHfXWXrUWY8HRK4PiK1XCLv.yL1XiLw.SNyfiHu3COPEjTA0DHoQVOhH2azEFco8laSUVb0UlaiUlHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhT2bkMkSyPjHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjWX2IBH1EFa0UVOhDCLv3BN3.CLvPCN3HCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
+										"blob" : "860.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.HVMjLgbw....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzRNtjyLv.CL2jyLzTyMvLSLxHxK9vCTAIUPMARZj0iHwcmHfXWXrUWY8HBLtjSN0.CLvDiLyjyM2XiMwDiHu3COPEjTA0DHoQVOhDGdh.hcgwVck0iHs.iKvDCM4jSN4HiMvjCLxPCLzfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL3XCLv.CL3PCN2bCLwPSL1HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HRKv3BLzHSN4jSN3HCNyLCN1HyLh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHw3xLvjSN4bSM0fSM4LyM0HxK9vCTAIUPMARZj0iHx8FcgQWZu41TkEWck41XkIBH1EFa0UVOhDiKvHxK9vCTAIUPMARZj0iH0MWYS4zLDIBH1EFa0UVOhDiKvHxK9vCTAIUPMARZj0iH4E1ch.hcgwVck0iHz3BNyjSN4XyLybCN4.iMxTiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
 									}
 ,
 									"fileref" : 									{
@@ -960,7 +1369,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1241.0, 926.5, 85.0, 22.0 ],
+					"patching_rect" : [ 736.5, 1170.0, 85.0, 22.0 ],
 					"text" : "s changeNmic"
 				}
 
@@ -972,7 +1381,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1241.0, 896.0, 32.0, 22.0 ],
+					"patching_rect" : [ 736.5, 1139.5, 32.0, 22.0 ],
 					"text" : "prev"
 				}
 
@@ -984,21 +1393,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1241.0, 864.0, 31.0, 22.0 ],
+					"patching_rect" : [ 736.5, 1107.5, 31.0, 22.0 ],
 					"text" : "next"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-64",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 65.5, 1268.6666259765625, 38.0, 22.0 ],
-					"text" : "r play"
 				}
 
 			}
@@ -1009,7 +1405,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1155.0, 859.0, 40.0, 22.0 ],
+					"patching_rect" : [ 723.5, 1065.0, 40.0, 22.0 ],
 					"text" : "s play"
 				}
 
@@ -1021,7 +1417,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1137.0, 885.5, 32.0, 22.0 ],
+					"patching_rect" : [ 703.928571428571445, 1095.0, 32.0, 22.0 ],
 					"text" : "s xB"
 				}
 
@@ -1033,7 +1429,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1119.0, 859.0, 32.0, 22.0 ],
+					"patching_rect" : [ 687.5, 1065.0, 32.0, 22.0 ],
 					"text" : "s xA"
 				}
 
@@ -1045,7 +1441,7 @@
 					"numinlets" : 8,
 					"numoutlets" : 8,
 					"outlettype" : [ "bang", "bang", "bang", "bang", "bang", "bang", "bang", "" ],
-					"patching_rect" : [ 1119.0, 810.0, 134.0, 22.0 ],
+					"patching_rect" : [ 687.5, 1035.0, 134.0, 22.0 ],
 					"text" : "sel 49 50 32 30 31 13 8"
 				}
 
@@ -1057,7 +1453,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 4,
 					"outlettype" : [ "int", "int", "int", "int" ],
-					"patching_rect" : [ 1119.0, 771.0, 50.5, 22.0 ],
+					"patching_rect" : [ 687.5, 1011.0, 50.5, 22.0 ],
 					"text" : "key"
 				}
 
@@ -1069,7 +1465,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 642.5, 1548.6488037109375, 101.0, 22.0 ],
+					"patching_rect" : [ 1001.0, 1536.535749167203903, 101.0, 22.0 ],
 					"text" : "prepend textcolor"
 				}
 
@@ -1082,7 +1478,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 681.0, 1516.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 1039.5, 1504.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOff"
 				}
 
@@ -1095,7 +1491,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 614.5, 1516.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 973.0, 1504.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOn"
 				}
 
@@ -1107,7 +1503,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 526.25, 1403.6666259765625, 29.5, 22.0 ],
+					"patching_rect" : [ 884.75, 1391.553571432828903, 29.5, 22.0 ],
 					"text" : "0"
 				}
 
@@ -1120,7 +1516,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 493.5, 1346.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 852.0, 1334.553571432828903, 60.0, 22.0 ],
 					"text" : "r testPath"
 				}
 
@@ -1132,7 +1528,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 493.5, 1403.6666259765625, 29.5, 22.0 ],
+					"patching_rect" : [ 852.0, 1391.553571432828903, 29.5, 22.0 ],
 					"text" : "1"
 				}
 
@@ -1147,7 +1543,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 493.5, 1436.6666259765625, 24.0, 24.0 ],
+					"patching_rect" : [ 852.0, 1424.553571432828903, 24.0, 24.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 237.5, 193.5, 24.0, 24.0 ],
 					"uncheckedcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ]
@@ -1162,7 +1558,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 493.5, 1369.1666259765625, 96.0, 22.0 ],
+					"patching_rect" : [ 852.0, 1357.053571432828903, 96.0, 22.0 ],
 					"text" : "r filesAreLoaded"
 				}
 
@@ -1174,7 +1570,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 574.5, 1498.6666259765625, 29.5, 22.0 ],
+					"patching_rect" : [ 933.0, 1486.553571432828903, 29.5, 22.0 ],
 					"text" : "1"
 				}
 
@@ -1187,7 +1583,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 574.5, 1469.6666259765625, 33.0, 22.0 ],
+					"patching_rect" : [ 933.0, 1457.553571432828903, 33.0, 22.0 ],
 					"text" : "r rep"
 				}
 
@@ -1200,7 +1596,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1156.5, 1346.6666259765625, 33.0, 22.0 ],
+					"patching_rect" : [ 1515.0, 1334.553571432828903, 33.0, 22.0 ],
 					"text" : "r rep"
 				}
 
@@ -1212,7 +1608,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 961.50006103515625, 1340.6666259765625, 71.0, 22.0 ],
+					"patching_rect" : [ 1320.00006103515625, 1328.553571432828903, 71.0, 22.0 ],
 					"text" : "s rep"
 				}
 
@@ -1225,7 +1621,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 656.5, 1631.6666259765625, 24.0, 24.0 ]
+					"patching_rect" : [ 1015.0, 1619.553571432828903, 24.0, 24.0 ]
 				}
 
 			}
@@ -1237,7 +1633,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 541.5, 1631.6666259765625, 24.0, 24.0 ]
+					"patching_rect" : [ 900.0, 1619.553571432828903, 24.0, 24.0 ]
 				}
 
 			}
@@ -1248,7 +1644,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1231.5, 1494.630859375, 95.0, 22.0 ],
+					"patching_rect" : [ 1590.0, 1482.517804831266403, 95.0, 22.0 ],
 					"text" : "prepend oncolor"
 				}
 
@@ -1260,7 +1656,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 777.0, 1331.6666259765625, 101.0, 22.0 ],
+					"patching_rect" : [ 1135.5, 1319.553571432828903, 101.0, 22.0 ],
 					"text" : "prepend textcolor"
 				}
 
@@ -1272,7 +1668,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 691.5, 1331.6666259765625, 101.0, 22.0 ],
+					"patching_rect" : [ 1050.0, 1319.553571432828903, 101.0, 22.0 ],
 					"text" : "prepend textcolor"
 				}
 
@@ -1284,7 +1680,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 608.5, 1331.6666259765625, 101.0, 22.0 ],
+					"patching_rect" : [ 967.0, 1319.553571432828903, 101.0, 22.0 ],
 					"text" : "prepend textcolor"
 				}
 
@@ -1363,29 +1759,12 @@
 			}
 , 			{
 				"box" : 				{
-					"bgcolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
-					"blinkcolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ],
-					"id" : "obj-259",
-					"maxclass" : "button",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"outlinecolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
-					"parameter_enable" : 0,
-					"patching_rect" : [ 65.5, 1301.6666259765625, 24.0, 24.0 ],
-					"presentation" : 1,
-					"presentation_rect" : [ 42.5, 221.517852783203125, 24.0, 24.0 ]
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
 					"id" : "obj-257",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1126.5, 1634.6666259765625, 69.0, 22.0 ],
+					"patching_rect" : [ 1485.0, 1622.553571432828903, 69.0, 22.0 ],
 					"text" : "s resetABX"
 				}
 
@@ -1398,7 +1777,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1231.5, 1466.6666259765625, 93.0, 22.0 ],
+					"patching_rect" : [ 1590.0, 1454.553571432828903, 93.0, 22.0 ],
 					"text" : "v incorrectColor"
 				}
 
@@ -1410,7 +1789,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1141.5, 1494.630859375, 55.0, 22.0 ],
+					"patching_rect" : [ 1500.0, 1482.517804831266403, 55.0, 22.0 ],
 					"text" : "pipe 500"
 				}
 
@@ -1422,7 +1801,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 1141.5, 1406.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 1500.0, 1394.553571432828903, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -1434,7 +1813,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 1186.5, 1406.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 1545.0, 1394.553571432828903, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -1447,7 +1826,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1231.5, 1433.1666259765625, 83.0, 22.0 ],
+					"patching_rect" : [ 1590.0, 1421.053571432828903, 83.0, 22.0 ],
 					"text" : "v correctColor"
 				}
 
@@ -1459,7 +1838,7 @@
 					"numinlets" : 3,
 					"numoutlets" : 3,
 					"outlettype" : [ "bang", "bang", "" ],
-					"patching_rect" : [ 1156.5, 1376.6666259765625, 44.0, 22.0 ],
+					"patching_rect" : [ 1515.0, 1364.553571432828903, 44.0, 22.0 ],
 					"text" : "sel 0 1"
 				}
 
@@ -1471,7 +1850,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "bang", "int", "int" ],
-					"patching_rect" : [ 1131.5, 1436.6666259765625, 42.0, 22.0 ],
+					"patching_rect" : [ 1490.0, 1424.553571432828903, 42.0, 22.0 ],
 					"text" : "t b 0 1"
 				}
 
@@ -1483,7 +1862,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 976.5, 1586.6666259765625, 58.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1574.553571432828903, 58.0, 22.0 ],
 					"text" : "loadbang"
 				}
 
@@ -1495,7 +1874,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 976.5, 1616.6666259765625, 112.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1604.553571432828903, 112.0, 22.0 ],
 					"text" : "0.631 0.278 0.18 1."
 				}
 
@@ -1508,7 +1887,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 976.5, 1646.6666259765625, 93.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1634.553571432828903, 93.0, 22.0 ],
 					"text" : "v incorrectColor"
 				}
 
@@ -1520,7 +1899,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 976.5, 1466.6666259765625, 58.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1454.553571432828903, 58.0, 22.0 ],
 					"text" : "loadbang"
 				}
 
@@ -1532,7 +1911,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 976.5, 1496.6666259765625, 119.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1484.553571432828903, 119.0, 22.0 ],
 					"text" : "0.384 0.627 0.337 1."
 				}
 
@@ -1545,7 +1924,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 976.5, 1541.6666259765625, 83.0, 22.0 ],
+					"patching_rect" : [ 1335.0, 1529.553571432828903, 83.0, 22.0 ],
 					"text" : "v correctColor"
 				}
 
@@ -1560,7 +1939,7 @@
 					"oncolor" : [ 0.384, 0.627, 0.337, 1.0 ],
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 1141.5, 1526.6666259765625, 65.964286804199219, 65.964286804199219 ],
+					"patching_rect" : [ 1500.0, 1514.553571432828903, 65.964286804199219, 65.964286804199219 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 375.0, 158.340061187744141, 65.964286804199219, 65.964286804199219 ]
 				}
@@ -1573,7 +1952,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 1036.5, 1316.6666259765625, 33.0, 22.0 ],
+					"patching_rect" : [ 1395.0, 1304.553571432828903, 33.0, 22.0 ],
 					"text" : "== 0"
 				}
 
@@ -1586,7 +1965,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1036.5, 1286.6666259765625, 42.0, 22.0 ],
+					"patching_rect" : [ 1395.0, 1274.553571432828903, 42.0, 22.0 ],
 					"text" : "v aIsX"
 				}
 
@@ -1599,7 +1978,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 961.50006103515625, 1286.6666259765625, 42.0, 22.0 ],
+					"patching_rect" : [ 1320.00006103515625, 1274.553571432828903, 42.0, 22.0 ],
 					"text" : "v aIsX"
 				}
 
@@ -1612,7 +1991,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1036.5, 1256.6666259765625, 30.0, 22.0 ],
+					"patching_rect" : [ 1395.0, 1244.553571432828903, 30.0, 22.0 ],
 					"text" : "r xB"
 				}
 
@@ -1625,7 +2004,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 961.50006103515625, 1256.6666259765625, 30.0, 22.0 ],
+					"patching_rect" : [ 1320.00006103515625, 1244.553571432828903, 30.0, 22.0 ],
 					"text" : "r xA"
 				}
 
@@ -1650,7 +2029,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 511.5, 1498.6666259765625, 29.5, 22.0 ],
+					"patching_rect" : [ 870.0, 1486.553571432828903, 29.5, 22.0 ],
 					"text" : "0"
 				}
 
@@ -1663,7 +2042,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 511.5, 1469.6666259765625, 59.0, 22.0 ],
+					"patching_rect" : [ 870.0, 1457.553571432828903, 59.0, 22.0 ],
 					"text" : "r endPlay"
 				}
 
@@ -1675,7 +2054,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 511.5, 1527.6666259765625, 82.0, 22.0 ],
+					"patching_rect" : [ 870.0, 1515.553571432828903, 82.0, 22.0 ],
 					"text" : "ignoreclick $1"
 				}
 
@@ -1688,7 +2067,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 511.5, 1256.6666259765625, 59.0, 22.0 ],
+					"patching_rect" : [ 870.0, 1244.553571432828903, 59.0, 22.0 ],
 					"text" : "r endPlay"
 				}
 
@@ -1701,7 +2080,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 517.0, 1284.6666259765625, 49.0, 22.0 ],
+					"patching_rect" : [ 875.5, 1272.553571432828903, 49.0, 22.0 ],
 					"text" : "r pause"
 				}
 
@@ -1714,7 +2093,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 777.0, 1241.6666259765625, 46.0, 22.0 ],
+					"patching_rect" : [ 1135.5, 1229.553571432828903, 46.0, 22.0 ],
 					"text" : "r playX"
 				}
 
@@ -1727,7 +2106,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 777.0, 1277.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 1135.5, 1265.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOn"
 				}
 
@@ -1740,7 +2119,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 691.5, 1241.6666259765625, 46.0, 22.0 ],
+					"patching_rect" : [ 1050.0, 1229.553571432828903, 46.0, 22.0 ],
 					"text" : "r playB"
 				}
 
@@ -1753,7 +2132,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 691.5, 1277.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 1050.0, 1265.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOn"
 				}
 
@@ -1766,7 +2145,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 511.5, 1312.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 870.0, 1300.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOff"
 				}
 
@@ -1779,7 +2158,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 608.5, 1277.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 967.0, 1265.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOn"
 				}
 
@@ -1791,7 +2170,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 770.0, 1572.6666259765625, 58.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1560.553571432828903, 58.0, 22.0 ],
 					"text" : "loadbang"
 				}
 
@@ -1803,7 +2182,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 770.0, 1601.6666259765625, 119.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1589.553571432828903, 119.0, 22.0 ],
 					"text" : "0.173 0.212 0.224 1."
 				}
 
@@ -1816,7 +2195,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 770.0, 1631.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1619.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOff"
 				}
 
@@ -1828,7 +2207,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 770.0, 1466.6666259765625, 58.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1454.553571432828903, 58.0, 22.0 ],
 					"text" : "loadbang"
 				}
 
@@ -1840,7 +2219,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 770.0, 1498.6666259765625, 119.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1486.553571432828903, 119.0, 22.0 ],
 					"text" : "0.635 0.482 0.361 1."
 				}
 
@@ -1853,7 +2232,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 770.0, 1541.6666259765625, 60.0, 22.0 ],
+					"patching_rect" : [ 1128.5, 1529.553571432828903, 60.0, 22.0 ],
 					"text" : "v colorOn"
 				}
 
@@ -1866,7 +2245,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 610.5, 1241.6666259765625, 46.0, 22.0 ],
+					"patching_rect" : [ 969.0, 1229.553571432828903, 46.0, 22.0 ],
 					"text" : "r playA"
 				}
 
@@ -1878,7 +2257,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 656.5, 1661.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 1015.0, 1649.553571432828903, 32.0, 22.0 ],
 					"text" : "s xB"
 				}
 
@@ -1890,7 +2269,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 541.5, 1661.6666259765625, 32.0, 22.0 ],
+					"patching_rect" : [ 900.0, 1649.553571432828903, 32.0, 22.0 ],
 					"text" : "s xA"
 				}
 
@@ -1915,7 +2294,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 656.5, 1586.6666259765625, 92.0, 37.0 ],
+					"patching_rect" : [ 1015.0, 1574.553571432828903, 92.0, 37.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 420.0, 100.626560211181641, 92.0, 37.0 ],
 					"text" : "X est B",
@@ -1944,7 +2323,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 541.5, 1586.6666259765625, 92.0, 37.0 ],
+					"patching_rect" : [ 900.0, 1574.553571432828903, 92.0, 37.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 305.0, 100.626560211181641, 92.0, 37.0 ],
 					"text" : "X est A",
@@ -1973,7 +2352,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 736.5, 1365.1666259765625, 30.0, 37.0 ],
+					"patching_rect" : [ 1095.0, 1353.053571432828903, 30.0, 37.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 465.0, 36.322208404541016, 30.0, 37.0 ],
 					"text" : "X",
@@ -2002,7 +2381,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 691.5, 1365.1666259765625, 30.0, 37.0 ],
+					"patching_rect" : [ 1050.0, 1353.053571432828903, 30.0, 37.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 390.0, 36.322208404541016, 30.0, 37.0 ],
 					"text" : "B",
@@ -2031,7 +2410,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 608.5, 1369.1666259765625, 50.0, 37.0 ],
+					"patching_rect" : [ 967.0, 1357.053571432828903, 50.0, 37.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 315.0, 36.322208404541016, 30.0, 37.0 ],
 					"text" : "A",
@@ -2042,321 +2421,12 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-102",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1290.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-10",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 2,
-					"outlettype" : [ "int", "int" ],
-					"patching_rect" : [ 320.5, 1392.6666259765625, 57.0, 22.0 ],
-					"text" : "minimum"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-9",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 9,
-					"outlettype" : [ "float", "list", "float", "float", "float", "float", "float", "", "int" ],
-					"patching_rect" : [ 262.0, 1321.0, 103.0, 22.0 ],
-					"text" : "info~ buff.1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-148",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1516.0, 51.0, 22.0 ],
-					"text" : "s pause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-149",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1516.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-147",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1392.0, 51.0, 22.0 ],
-					"text" : "s pause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-146",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1392.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-106",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1614.0, 74.0, 20.0 ],
-					"text" : "X is playing"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-109",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 270.0, 1252.0, 81.0, 22.0 ],
-					"text" : "r dureePause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-110",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 358.5, 1358.6666259765625, 71.0, 22.0 ],
-					"text" : "r dureeStim"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-111",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 253.029541015625, 1665.0, 61.0, 22.0 ],
-					"text" : "s endPlay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-94",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 150.0, 1614.0, 37.0, 22.0 ],
-					"text" : "delay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-95",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1585.0, 48.0, 22.0 ],
-					"text" : "s playX"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-112",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1585.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-90",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1546.0, 48.0, 20.0 ],
-					"text" : "pause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-91",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1487.0, 74.0, 20.0 ],
-					"text" : "B is playing"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-88",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 150.0, 1546.0, 37.0, 22.0 ],
-					"text" : "delay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-89",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 150.0, 1487.0, 37.0, 22.0 ],
-					"text" : "delay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-113",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1458.0, 48.0, 22.0 ],
-					"text" : "s playB"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-114",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1458.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-72",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1424.0, 48.0, 20.0 ],
-					"text" : "pause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-71",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 150.0, 1424.0, 37.0, 22.0 ],
-					"text" : "delay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-56",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1362.0, 74.0, 20.0 ],
-					"text" : "A is playing"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-115",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 189.5, 1321.0, 48.0, 22.0 ],
-					"text" : "s playA"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-46",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 150.0, 1362.0, 37.0, 22.0 ],
-					"text" : "delay"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-45",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 150.0, 1321.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
 					"id" : "obj-178",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 777.5, 960.0, 71.0, 22.0 ],
+					"patching_rect" : [ 775.0, 945.0, 71.0, 22.0 ],
 					"text" : "s fileToPlay"
 				}
 
@@ -2368,7 +2438,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 777.5, 930.0, 29.5, 22.0 ],
+					"patching_rect" : [ 775.0, 915.0, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2380,7 +2450,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 777.5, 900.0, 29.5, 22.0 ],
+					"patching_rect" : [ 775.0, 885.0, 29.5, 22.0 ],
 					"text" : "!="
 				}
 
@@ -2393,7 +2463,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 777.5, 840.0, 42.0, 22.0 ],
+					"patching_rect" : [ 775.0, 825.0, 42.0, 22.0 ],
 					"text" : "v aIsX"
 				}
 
@@ -2406,7 +2476,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 790.5, 870.0, 52.0, 22.0 ],
+					"patching_rect" : [ 788.0, 855.0, 52.0, 22.0 ],
 					"text" : "v xIsRef"
 				}
 
@@ -2418,7 +2488,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 777.5, 810.0, 32.0, 22.0 ],
+					"patching_rect" : [ 775.0, 795.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2430,7 +2500,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 690.0, 960.0, 71.0, 22.0 ],
+					"patching_rect" : [ 687.5, 945.0, 71.0, 22.0 ],
 					"text" : "s fileToPlay"
 				}
 
@@ -2442,7 +2512,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 690.0, 930.0, 29.5, 22.0 ],
+					"patching_rect" : [ 687.5, 915.0, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2454,7 +2524,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 690.0, 900.0, 29.5, 22.0 ],
+					"patching_rect" : [ 687.5, 885.0, 29.5, 22.0 ],
 					"text" : "=="
 				}
 
@@ -2467,7 +2537,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 690.0, 840.0, 42.0, 22.0 ],
+					"patching_rect" : [ 687.5, 825.0, 42.0, 22.0 ],
 					"text" : "v aIsX"
 				}
 
@@ -2480,7 +2550,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 703.0, 870.0, 52.0, 22.0 ],
+					"patching_rect" : [ 700.5, 855.0, 52.0, 22.0 ],
 					"text" : "v xIsRef"
 				}
 
@@ -2492,7 +2562,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 690.0, 810.0, 32.0, 22.0 ],
+					"patching_rect" : [ 687.5, 795.0, 32.0, 22.0 ],
 					"text" : "t b b"
 				}
 
@@ -2504,7 +2574,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 876.0, 870.0, 71.0, 22.0 ],
+					"patching_rect" : [ 873.5, 855.0, 71.0, 22.0 ],
 					"text" : "s fileToPlay"
 				}
 
@@ -2516,7 +2586,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 876.0, 840.0, 29.5, 22.0 ],
+					"patching_rect" : [ 873.5, 825.0, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2529,7 +2599,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 876.0, 810.0, 52.0, 22.0 ],
+					"patching_rect" : [ 873.5, 795.0, 52.0, 22.0 ],
 					"text" : "v xIsRef"
 				}
 
@@ -2542,7 +2612,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 876.0, 780.0, 46.0, 22.0 ],
+					"patching_rect" : [ 873.5, 765.0, 46.0, 22.0 ],
 					"text" : "r playX"
 				}
 
@@ -2555,7 +2625,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 777.5, 780.0, 46.0, 22.0 ],
+					"patching_rect" : [ 775.0, 765.0, 46.0, 22.0 ],
 					"text" : "r playB"
 				}
 
@@ -2568,7 +2638,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 690.0, 780.0, 46.0, 22.0 ],
+					"patching_rect" : [ 687.5, 765.0, 46.0, 22.0 ],
 					"text" : "r playA"
 				}
 
@@ -3155,7 +3225,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 945.0, 295.702117919921875, 62.0, 22.0 ],
+					"patching_rect" : [ 870.5, 271.0, 62.0, 22.0 ],
 					"text" : "s testPath"
 				}
 
@@ -3167,7 +3237,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 945.0, 319.702117919921875, 57.0, 22.0 ],
+					"patching_rect" : [ 685.5, 323.0, 57.0, 22.0 ],
 					"text" : "s refPath"
 				}
 
@@ -3180,7 +3250,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 945.0, 264.0, 62.0, 22.0 ],
+					"patching_rect" : [ 799.5, 276.0, 62.0, 22.0 ],
 					"text" : "r refName"
 				}
 
@@ -3192,7 +3262,7 @@
 					"numinlets" : 3,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 690.0, 300.0, 247.0, 22.0 ],
+					"patching_rect" : [ 685.5, 300.0, 247.0, 22.0 ],
 					"text" : "combine folderPath refPath .wav @triggers 1"
 				}
 
@@ -3205,7 +3275,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 945.0, 240.0, 67.0, 22.0 ],
+					"patching_rect" : [ 985.5, 225.0, 67.0, 22.0 ],
 					"text" : "r testName"
 				}
 
@@ -3218,7 +3288,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 690.0, 240.0, 71.0, 22.0 ],
+					"patching_rect" : [ 685.5, 238.0, 71.0, 22.0 ],
 					"text" : "r folderPath"
 				}
 
@@ -3230,7 +3300,7 @@
 					"numinlets" : 3,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 690.0, 270.0, 249.0, 22.0 ],
+					"patching_rect" : [ 870.5, 247.0, 249.0, 22.0 ],
 					"text" : "combine folderPath filePath .wav @triggers 1"
 				}
 
@@ -3334,11 +3404,12 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-4",
+					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 11,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 237.0, 555.0, 537.0, 22.0 ],
+					"patching_rect" : [ 237.0, 555.0, 346.0, 36.0 ],
 					"text" : "combine quartet _ broadcastingstudio _ Extremal _ 64 _ 6cm _o7 _90 @padding 0 0 0 0 0 0 4 0 0 0"
 				}
 
@@ -3572,7 +3643,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1052.0, 735.0, 120.0, 20.0 ],
+					"patching_rect" : [ 675.0, 990.0, 120.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Shortcuts"
 				}
@@ -3590,7 +3661,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1052.0, 735.0, 360.0, 315.0 ],
+					"patching_rect" : [ 675.0, 990.0, 360.0, 210.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -3635,7 +3706,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 946.5, 1226.6666259765625, 120.0, 20.0 ],
+					"patching_rect" : [ 1305.0, 1214.553571432828903, 120.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Reponse"
 				}
@@ -3653,7 +3724,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 946.5, 1226.6666259765625, 450.0, 465.0 ],
+					"patching_rect" : [ 1305.0, 1214.553571432828903, 450.0, 465.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -3666,7 +3737,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 481.5, 1226.6666259765625, 120.0, 20.0 ],
+					"patching_rect" : [ 840.0, 1214.553571432828903, 120.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Interface"
 				}
@@ -3684,7 +3755,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 481.5, 1226.6666259765625, 450.0, 465.0 ],
+					"patching_rect" : [ 840.0, 1214.553571432828903, 450.0, 465.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -3777,7 +3848,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 675.0, 214.0, 360.0, 131.0 ],
+					"patching_rect" : [ 675.0, 214.0, 449.61038875579834, 131.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -3915,38 +3986,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 675.0, 735.0, 360.0, 315.0 ],
-					"proportion" : 0.5,
-					"prototypename" : "backgroundPanel"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"background" : 1,
-					"id" : "obj-62",
-					"maxclass" : "comment",
-					"numinlets" : 0,
-					"numoutlets" : 0,
-					"patching_rect" : [ 10.5, 1226.6666259765625, 120.0, 20.0 ],
-					"suppressinlet" : 1,
-					"text" : "Ecoute séquentielle"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"angle" : 270.0,
-					"background" : 1,
-					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
-					"border" : 1,
-					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
-					"id" : "obj-63",
-					"maxclass" : "panel",
-					"mode" : 0,
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 10.5, 1226.6666259765625, 450.0, 465.0 ],
+					"patching_rect" : [ 675.0, 735.0, 359.5, 240.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -3959,7 +3999,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1335.0, 300.0, 165.0, 20.0 ],
+					"patching_rect" : [ 1245.0, 735.0, 165.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Rotation vers l'origine du T3"
 				}
@@ -3973,7 +4013,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1140.0, 540.0, 150.0, 34.0 ],
+					"patching_rect" : [ 1050.0, 990.0, 150.0, 34.0 ],
 					"suppressinlet" : 1,
 					"text" : "Envoi vers SceneRotator:\nW X Y Z"
 				}
@@ -3991,7 +4031,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1140.0, 540.0, 182.0, 180.0 ],
+					"patching_rect" : [ 1050.0, 990.0, 180.0, 210.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -4009,7 +4049,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1335.0, 300.0, 300.0, 420.0 ],
+					"patching_rect" : [ 1245.0, 735.0, 300.0, 465.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -4023,7 +4063,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1140.0, 300.0, 135.0, 34.0 ],
+					"patching_rect" : [ 1050.0, 735.0, 135.0, 34.0 ],
 					"suppressinlet" : 1,
 					"text" : "Sortie du HeadTracker:\nW X Y Z"
 				}
@@ -4041,7 +4081,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1140.0, 300.0, 182.0, 225.0 ],
+					"patching_rect" : [ 1050.0, 735.0, 180.0, 240.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -4055,7 +4095,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1440.0, 440.0, 180.0, 75.0 ],
+					"patching_rect" : [ 1350.0, 875.0, 180.0, 75.0 ],
 					"suppressinlet" : 1,
 					"text" : "Qoffset = Q0* \n(Q0: rotation de l'origine du repère à l'origine souhaitée)\n\n=> Qtot = Qoffset * QheadTrack"
 				}
@@ -4068,38 +4108,45 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1335.0, 300.0, 165.0, 20.0 ],
+					"patching_rect" : [ 1245.0, 735.0, 165.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Rotation vers origine du T3"
 				}
 
 			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-287",
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 9.0, 1215.0, 120.0, 20.0 ],
+					"suppressinlet" : 1,
+					"text" : "Ecoute séquentielle"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-288",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 9.0, 1214.553571432828903, 814.5, 474.446428567171097 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
+				}
+
+			}
  ],
 		"lines" : [ 			{
-				"patchline" : 				{
-					"destination" : [ "obj-46", 1 ],
-					"order" : 2,
-					"source" : [ "obj-10", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-89", 1 ],
-					"order" : 1,
-					"source" : [ "obj-10", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-94", 1 ],
-					"order" : 0,
-					"source" : [ "obj-10", 0 ]
-				}
-
-			}
-, 			{
 				"patchline" : 				{
 					"destination" : [ "obj-49", 0 ],
 					"source" : [ "obj-100", 0 ]
@@ -4110,20 +4157,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-131", 0 ],
 					"source" : [ "obj-101", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-45", 0 ],
-					"source" : [ "obj-102", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 0 ],
-					"source" : [ "obj-102", 1 ]
 				}
 
 			}
@@ -4171,66 +4204,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-71", 1 ],
-					"order" : 1,
-					"source" : [ "obj-109", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-88", 1 ],
-					"order" : 0,
-					"source" : [ "obj-109", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-184", 0 ],
 					"source" : [ "obj-11", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-10", 1 ],
-					"source" : [ "obj-110", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-94", 0 ],
-					"source" : [ "obj-112", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-95", 0 ],
-					"source" : [ "obj-112", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-113", 0 ],
-					"source" : [ "obj-114", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-89", 0 ],
-					"source" : [ "obj-114", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-102", 0 ],
-					"source" : [ "obj-119", 0 ]
 				}
 
 			}
@@ -4243,8 +4218,22 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-119", 0 ],
-					"source" : [ "obj-120", 0 ]
+					"destination" : [ "obj-166", 0 ],
+					"source" : [ "obj-121", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-270", 3 ],
+					"source" : [ "obj-121", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-275", 0 ],
+					"source" : [ "obj-121", 2 ]
 				}
 
 			}
@@ -4343,36 +4332,29 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-123", 0 ],
+					"source" : [ "obj-143", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-124", 0 ],
+					"source" : [ "obj-143", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-139", 0 ],
+					"source" : [ "obj-143", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-134", 0 ],
 					"source" : [ "obj-144", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-147", 0 ],
-					"source" : [ "obj-146", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-71", 0 ],
-					"source" : [ "obj-146", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-148", 0 ],
-					"source" : [ "obj-149", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-88", 0 ],
-					"source" : [ "obj-149", 0 ]
 				}
 
 			}
@@ -4434,6 +4416,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-143", 0 ],
+					"source" : [ "obj-160", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-195", 0 ],
 					"source" : [ "obj-163", 0 ]
 				}
@@ -4443,6 +4432,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-167", 0 ],
 					"source" : [ "obj-164", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-221", 0 ],
+					"source" : [ "obj-166", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-266", 0 ],
+					"source" : [ "obj-166", 1 ]
 				}
 
 			}
@@ -4485,6 +4488,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-175", 0 ],
 					"source" : [ "obj-172", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-166", 0 ],
+					"source" : [ "obj-173", 0 ]
 				}
 
 			}
@@ -4567,6 +4577,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-192", 1 ],
+					"source" : [ "obj-186", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-165", 0 ],
 					"source" : [ "obj-187", 0 ]
 				}
@@ -4590,6 +4607,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-190", 0 ],
 					"source" : [ "obj-191", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-185", 0 ],
+					"source" : [ "obj-192", 0 ]
 				}
 
 			}
@@ -4712,6 +4736,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-192", 0 ],
+					"source" : [ "obj-206", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-203", 0 ],
+					"source" : [ "obj-206", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-231", 0 ],
 					"source" : [ "obj-207", 0 ]
 				}
@@ -4730,6 +4768,13 @@
 					"destination" : [ "obj-25", 0 ],
 					"order" : 0,
 					"source" : [ "obj-208", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-270", 0 ],
+					"source" : [ "obj-209", 0 ]
 				}
 
 			}
@@ -4765,6 +4810,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-220", 1 ],
+					"source" : [ "obj-216", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-230", 0 ],
 					"source" : [ "obj-217", 0 ]
 				}
@@ -4788,6 +4840,27 @@
 				"patchline" : 				{
 					"destination" : [ "obj-24", 0 ],
 					"source" : [ "obj-22", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-206", 0 ],
+					"source" : [ "obj-220", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-212", 0 ],
+					"source" : [ "obj-221", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-220", 0 ],
+					"source" : [ "obj-221", 0 ]
 				}
 
 			}
@@ -4998,6 +5071,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-258", 1 ],
+					"source" : [ "obj-249", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-30", 0 ],
 					"source" : [ "obj-25", 0 ]
 				}
@@ -5091,8 +5171,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-348", 0 ],
-					"source" : [ "obj-259", 0 ]
+					"destination" : [ "obj-321", 0 ],
+					"source" : [ "obj-258", 0 ]
 				}
 
 			}
@@ -5119,6 +5199,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-258", 0 ],
+					"source" : [ "obj-266", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-264", 0 ],
+					"source" : [ "obj-266", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-269", 0 ],
 					"source" : [ "obj-267", 0 ]
 				}
@@ -5133,8 +5227,43 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-166", 1 ],
+					"source" : [ "obj-270", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-173", 0 ],
+					"source" : [ "obj-270", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-248", 0 ],
+					"source" : [ "obj-272", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-193", 0 ],
 					"source" : [ "obj-273", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-272", 0 ],
+					"source" : [ "obj-274", 6 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-121", 0 ],
+					"source" : [ "obj-275", 0 ]
 				}
 
 			}
@@ -5154,8 +5283,29 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-275", 0 ],
+					"source" : [ "obj-279", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-30", 0 ],
 					"source" : [ "obj-28", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-272", 1 ],
+					"source" : [ "obj-280", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-290", 0 ],
+					"source" : [ "obj-281", 0 ]
 				}
 
 			}
@@ -5177,6 +5327,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-155", 0 ],
 					"source" : [ "obj-286", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-274", 0 ],
+					"source" : [ "obj-289", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-275", 1 ],
+					"source" : [ "obj-290", 0 ]
 				}
 
 			}
@@ -5389,6 +5553,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-223", 0 ],
+					"source" : [ "obj-321", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-323", 0 ],
+					"source" : [ "obj-321", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-49", 0 ],
 					"source" : [ "obj-322", 0 ]
 				}
@@ -5412,34 +5590,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-70", 0 ],
 					"source" : [ "obj-33", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-119", 1 ],
-					"source" : [ "obj-348", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-119", 0 ],
-					"source" : [ "obj-348", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-111", 0 ],
-					"source" : [ "obj-349", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-350", 0 ],
-					"source" : [ "obj-349", 0 ]
 				}
 
 			}
@@ -5488,7 +5638,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-40", 0 ],
-					"order" : 1,
+					"order" : 0,
 					"source" : [ "obj-42", 0 ]
 				}
 
@@ -5496,7 +5646,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-47", 0 ],
-					"order" : 0,
+					"order" : 1,
 					"source" : [ "obj-42", 0 ]
 				}
 
@@ -5519,27 +5669,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-40", 1 ],
 					"source" : [ "obj-44", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-115", 0 ],
-					"source" : [ "obj-45", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-46", 0 ],
-					"source" : [ "obj-45", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-146", 0 ],
-					"source" : [ "obj-46", 0 ]
 				}
 
 			}
@@ -5657,13 +5786,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-259", 0 ],
-					"source" : [ "obj-64", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-8", 0 ],
 					"source" : [ "obj-65", 0 ]
 				}
@@ -5717,13 +5839,6 @@
 					"destination" : [ "obj-52", 0 ],
 					"order" : 1,
 					"source" : [ "obj-7", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-114", 0 ],
-					"source" : [ "obj-71", 0 ]
 				}
 
 			}
@@ -5799,27 +5914,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-112", 0 ],
-					"source" : [ "obj-88", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-149", 0 ],
-					"source" : [ "obj-89", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-10", 0 ],
-					"source" : [ "obj-9", 6 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-31", 0 ],
 					"order" : 0,
 					"source" : [ "obj-92", 0 ]
@@ -5870,13 +5964,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-122", 0 ],
 					"source" : [ "obj-93", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-349", 0 ],
-					"source" : [ "obj-94", 0 ]
 				}
 
 			}

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 1954.0, 81.0, 842.0, 883.0 ],
+		"rect" : [ 1954.0, 81.0, 1212.0, 883.0 ],
 		"bglocked" : 1,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -39,6 +39,348 @@
 		"subpatcher_template" : "ManipAliasingSpatial",
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-347",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1305.0, 840.0, 76.0, 22.0 ],
+					"text" : "s resetOffset"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-322",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 525.0, 953.0, 93.0, 22.0 ],
+					"text" : "r sceneRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-222",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1350.0, 405.0, 74.0, 22.0 ],
+					"text" : "r resetOffset"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-291",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1395.5, 563.5, 113.0, 22.0 ],
+					"text" : "loadmess 0. 0. 0. 1."
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-292",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 1540.5, 569.5, 29.5, 22.0 ],
+					"text" : "t b l"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.847058823529412, 0.76078431372549, 0.337254901960784, 1.0 ],
+					"id" : "obj-104",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1350.0, 613.5, 54.0, 22.0 ],
+					"text" : "pv offset"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-294",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1350.0, 684.0, 91.0, 22.0 ],
+					"text" : "s centeredQuat"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-295",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1540.5, 539.5, 72.0, 22.0 ],
+					"text" : "r headTrack"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-296",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 1375.0, 534.0, 78.0, 22.0 ],
+					"text" : "route inverse"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-297",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "list", "" ],
+					"patching_rect" : [ 1350.0, 501.5, 44.0, 22.0 ],
+					"text" : "jit.quat"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-298",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 1350.0, 473.5, 77.0, 22.0 ],
+					"text" : "t getinverse l"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-300",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "list", "" ],
+					"patching_rect" : [ 1350.0, 649.5, 220.0, 22.0 ],
+					"text" : "jit.quat @quat2 0. 0. 0. 1. @normalize 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-305",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1427.658536672592163, 405.0, 72.0, 22.0 ],
+					"text" : "r headTrack"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-307",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1350.0, 444.0, 31.0, 22.0 ],
+					"text" : "pv q"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-308",
+					"maxclass" : "button",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 1350.0, 334.615379571914673, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-309",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1350.0, 364.615379571914673, 76.0, 22.0 ],
+					"text" : "s resetOffset"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-144",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1145.0, 369.615379571914673, 77.0, 22.0 ],
+					"text" : "prepend port"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-310",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1145.0, 336.615379571914673, 58.0, 22.0 ],
+					"text" : "r udpPort"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-311",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1145.0, 459.615379571914673, 72.0, 22.0 ],
+					"text" : "$2 $3 $4 $1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-312",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1151.5, 690.0, 95.0, 22.0 ],
+					"text" : "s sceneRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-313",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1151.5, 576.0, 89.0, 22.0 ],
+					"text" : "r centeredQuat"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-314",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1151.5, 605.5, 106.0, 22.0 ],
+					"text" : "vexpr ($f1 + 1) / 2."
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-315",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 1151.5, 661.317073345184326, 61.0, 22.0 ],
+					"text" : "zl.group 2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-169",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1151.5, 633.780488967895508, 112.0, 22.0 ],
+					"text" : "6 $4 7 $1 8 $2 9 $3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.631372549019608, 0.27843137254902, 0.180392156862745, 1.0 ],
+					"id" : "obj-136",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1145.0, 497.0, 74.0, 22.0 ],
+					"text" : "s headTrack"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-316",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1221.0, 459.615379571914673, 101.0, 20.0 ],
+					"text" : "jit.quat: X Y Z W"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-133",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 1145.0, 423.615379571914673, 102.0, 22.0 ],
+					"text" : "route /Quaternion"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-134",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1145.0, 396.0, 97.0, 22.0 ],
+					"text" : "udpreceive 4040"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-174",
 					"maxclass" : "message",
@@ -360,30 +702,6 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-86",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 5,
-					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 493.5, 906.0, 139.0, 22.0 ],
-					"text" : "regexp / @substitute %0"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-66",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 493.5, 876.0, 97.0, 22.0 ],
-					"text" : "udpreceive 4040"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"autosave" : 1,
 					"bgmode" : 0,
 					"border" : 0,
@@ -398,8 +716,8 @@
 					"numoutlets" : 7,
 					"offset" : [ 0.0, 0.0 ],
 					"outlettype" : [ "multichannelsignal", "", "list", "int", "", "", "" ],
-					"patching_rect" : [ 384.0, 990.0, 202.0, 22.0 ],
-					"save" : [ "#N", "mcs.vst~", "loaduniqueid", 0, 64, 64, "ambix_rotator_o7.dll", ";" ],
+					"patching_rect" : [ 384.0, 990.0, 181.0, 22.0 ],
+					"save" : [ "#N", "mcs.vst~", "loaduniqueid", 0, 64, 64, "SceneRotator.dll", ";" ],
 					"saved_attribute_attributes" : 					{
 						"valueof" : 						{
 							"parameter_invisible" : 1,
@@ -425,14 +743,14 @@
 						"subtype" : "Undefined",
 						"embed" : 1,
 						"snapshot" : 						{
-							"pluginname" : "ambix_rotator_o7.dll",
-							"plugindisplayname" : "ambix_rotator_o7",
+							"pluginname" : "SceneRotator.dll",
+							"plugindisplayname" : "SceneRotator",
 							"pluginsavedname" : "",
 							"pluginsaveduniqueid" : 0,
 							"version" : 1,
 							"isbank" : 0,
 							"isbase64" : 1,
-							"blob" : "228.CMlaKA....fQPMDZ....ADjTucC....Y....A..........................................pVMjLg7I....OMkETLU0QI4zTEQEUI4zQSABL8HBLtLCN3bSLyjCN0XCNwTyLyfSLyPCNh.RL8HBLtTCLvDSMwjSNwfCMzDyM2HCM1.SNh.hL8HBLtPSN4.SMzjSN3DSM4PCL3TiM4LCMh.xL8HBLh.BM8HBLtTiHfTSOh.iK0HBH1ziHv3RMh.xM8HBLtTiHffSOh.iHf7UbeMFZg41YkQVOh.iHu3C."
+							"blob" : "848.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.EVMjLgrv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxMtTiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHv3RN4bCLv.CL4fiLxfCM0PiMh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKvHSLv.CLvHyM1TiM0TSMwfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL1TCLv.CL0biLx.CM0fSN3HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HBLt.SL2.CLv.yM4DSMzjiM3HiMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsHiKy.CLv.yLvTSL2TyM3DiLh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HRKw3BNv.CLvLCL0DyM0bCNwHiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
 						}
 ,
 						"snapshotlist" : 						{
@@ -441,46 +759,28 @@
 									"filetype" : "C74Snapshot",
 									"version" : 2,
 									"minorversion" : 0,
-									"name" : "ambix_rotator_o7",
-									"origin" : "ambix_rotator_o7.dll",
+									"name" : "SceneRotator",
+									"origin" : "SceneRotator.dll",
 									"type" : "VST",
 									"subtype" : "AudioEffect",
 									"embed" : 0,
 									"snapshot" : 									{
-										"pluginname" : "ambix_rotator_o7.dll",
-										"plugindisplayname" : "ambix_rotator_o7",
+										"pluginname" : "SceneRotator.dll",
+										"plugindisplayname" : "SceneRotator",
 										"pluginsavedname" : "",
 										"pluginsaveduniqueid" : 0,
 										"version" : 1,
 										"isbank" : 0,
 										"isbase64" : 1,
-										"blob" : "228.CMlaKA....fQPMDZ....ADjTucC....Y....A..........................................pVMjLg7I....OMkETLU0QI4zTEQEUI4zQSABL8HBLtLCN3bSLyjCN0XCNwTyLyfSLyPCNh.RL8HBLtTCLvDSMwjSNwfCMzDyM2HCM1.SNh.hL8HBLtPSN4.SMzjSN3DSM4PCL3TiM4LCMh.xL8HBLh.BM8HBLtTiHfTSOh.iK0HBH1ziHv3RMh.xM8HBLtTiHffSOh.iHf7UbeMFZg41YkQVOh.iHu3C."
+										"blob" : "848.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.EVMjLgrv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxMtTiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHv3RN4bCLv.CL4fiLxfCM0PiMh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKvHSLv.CLvHyM1TiM0TSMwfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL1TCLv.CL0biLx.CM0fSN3HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HBLt.SL2.CLv.yM4DSMzjiM3HiMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsHiKy.CLv.yLvTSL2TyM3DiLh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HRKw3BNv.CLvLCL0DyM0bCNwHiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
 									}
 ,
 									"fileref" : 									{
-										"name" : "ambix_rotator_o7",
-										"filename" : "ambix_rotator_o7.maxsnap",
+										"name" : "SceneRotator",
+										"filename" : "SceneRotator.maxsnap",
 										"filepath" : "~/Documents/Max 8/Snapshots",
 										"filepos" : -1,
-										"snapshotfileid" : "63770a883ada35eecaa83b86000a5e07"
-									}
-
-								}
-, 								{
-									"filetype" : "C74Snapshot",
-									"version" : 2,
-									"minorversion" : 0,
-									"name" : "ambix_rotator_o7",
-									"origin" : "ambix_rotator_o7.dll",
-									"type" : "VST",
-									"subtype" : "AudioEffect",
-									"embed" : 0,
-									"fileref" : 									{
-										"name" : "ambix_rotator_o7",
-										"filename" : "ambix_rotator_o7_20230106.maxsnap",
-										"filepath" : "~/Documents/Max 8/Snapshots",
-										"filepos" : -1,
-										"snapshotfileid" : "3662b5ee41b36475e6be07309bfb4253"
+										"snapshotfileid" : "307330e6b0231b12db1895fed52360de"
 									}
 
 								}
@@ -489,7 +789,7 @@
 
 					}
 ,
-					"text" : "mcs.vst~ 64 64 ambix_rotator_o7.dll",
+					"text" : "mcs.vst~ 64 64 SceneRotator.dll",
 					"varname" : "mcs.vst~",
 					"viewvisibility" : 0
 				}
@@ -675,11 +975,11 @@
 				"box" : 				{
 					"id" : "obj-55",
 					"maxclass" : "newobj",
-					"numinlets" : 7,
-					"numoutlets" : 7,
-					"outlettype" : [ "bang", "bang", "bang", "bang", "bang", "bang", "" ],
-					"patching_rect" : [ 1119.0, 810.0, 124.0, 22.0 ],
-					"text" : "sel 49 50 32 30 31 13"
+					"numinlets" : 8,
+					"numoutlets" : 8,
+					"outlettype" : [ "bang", "bang", "bang", "bang", "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 1119.0, 810.0, 134.0, 22.0 ],
+					"text" : "sel 49 50 32 30 31 13 8"
 				}
 
 			}
@@ -3586,6 +3886,131 @@
 				}
 
 			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-317",
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1335.0, 300.0, 165.0, 20.0 ],
+					"suppressinlet" : 1,
+					"text" : "Rotation vers l'origine du T3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-135",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1140.0, 540.0, 150.0, 34.0 ],
+					"presentation_linecount" : 2,
+					"suppressinlet" : 1,
+					"text" : "Envoi vers SceneRotator:\nW X Y Z"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-138",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1140.0, 540.0, 182.0, 180.0 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-318",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1335.0, 300.0, 300.0, 420.0 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-142",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1140.0, 300.0, 135.0, 34.0 ],
+					"presentation_linecount" : 2,
+					"suppressinlet" : 1,
+					"text" : "Sortie du HeadTracker:\nW X Y Z"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-319",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1140.0, 300.0, 182.0, 225.0 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-320",
+					"linecount" : 5,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1440.0, 440.0, 180.0, 75.0 ],
+					"presentation_linecount" : 5,
+					"suppressinlet" : 1,
+					"text" : "Qoffset = Q0* \n(Q0: rotation de l'origine du repère à l'origine souhaitée)\n\n=> Qtot = Qoffset * QheadTrack"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-211",
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 1335.0, 300.0, 165.0, 20.0 ],
+					"suppressinlet" : 1,
+					"text" : "Rotation vers origine du T3"
+				}
+
+			}
  ],
 		"lines" : [ 			{
 				"patchline" : 				{
@@ -3636,6 +4061,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
 					"source" : [ "obj-102", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-300", 0 ],
+					"source" : [ "obj-104", 0 ]
 				}
 
 			}
@@ -3820,6 +4252,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-311", 0 ],
+					"source" : [ "obj-133", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-133", 0 ],
+					"source" : [ "obj-134", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-8", 0 ],
 					"source" : [ "obj-14", 0 ]
 				}
@@ -3829,6 +4275,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-93", 0 ],
 					"source" : [ "obj-140", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-134", 0 ],
+					"source" : [ "obj-144", 0 ]
 				}
 
 			}
@@ -3927,6 +4380,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-167", 0 ],
 					"source" : [ "obj-164", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-315", 0 ],
+					"source" : [ "obj-169", 0 ]
 				}
 
 			}
@@ -4265,6 +4725,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-24", 0 ],
 					"source" : [ "obj-22", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-307", 0 ],
+					"source" : [ "obj-222", 0 ]
 				}
 
 			}
@@ -4652,8 +5119,64 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-104", 0 ],
+					"source" : [ "obj-291", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-104", 0 ],
+					"source" : [ "obj-292", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-300", 1 ],
+					"source" : [ "obj-292", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-240", 0 ],
 					"source" : [ "obj-293", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-292", 0 ],
+					"source" : [ "obj-295", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-104", 0 ],
+					"source" : [ "obj-296", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-296", 0 ],
+					"source" : [ "obj-297", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-297", 1 ],
+					"source" : [ "obj-298", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-297", 0 ],
+					"source" : [ "obj-298", 0 ]
 				}
 
 			}
@@ -4689,6 +5212,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-294", 0 ],
+					"source" : [ "obj-300", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-162", 0 ],
 					"source" : [ "obj-301", 0 ]
 				}
@@ -4719,8 +5249,29 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-307", 0 ],
+					"source" : [ "obj-305", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-205", 0 ],
 					"source" : [ "obj-306", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-298", 0 ],
+					"source" : [ "obj-307", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-309", 0 ],
+					"source" : [ "obj-308", 0 ]
 				}
 
 			}
@@ -4735,6 +5286,48 @@
 				"patchline" : 				{
 					"destination" : [ "obj-67", 0 ],
 					"source" : [ "obj-31", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-144", 0 ],
+					"source" : [ "obj-310", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-136", 0 ],
+					"source" : [ "obj-311", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-314", 0 ],
+					"source" : [ "obj-313", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-169", 0 ],
+					"source" : [ "obj-314", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-312", 0 ],
+					"source" : [ "obj-315", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-49", 0 ],
+					"source" : [ "obj-322", 0 ]
 				}
 
 			}
@@ -4910,6 +5503,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-347", 0 ],
+					"source" : [ "obj-55", 6 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-57", 0 ],
 					"source" : [ "obj-55", 0 ]
 				}
@@ -4975,13 +5575,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-8", 0 ],
 					"source" : [ "obj-65", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-86", 0 ],
-					"source" : [ "obj-66", 0 ]
 				}
 
 			}
@@ -5115,13 +5708,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-49", 0 ],
-					"source" : [ "obj-86", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-112", 0 ],
 					"source" : [ "obj-88", 0 ]
 				}
@@ -5217,14 +5803,7 @@
 				"implicit" : 1
 			}
 , 			{
-				"name" : "ambix_rotator_o7.maxsnap",
-				"bootpath" : "~/Documents/Max 8/Snapshots",
-				"patcherrelativepath" : "../../../../Snapshots",
-				"type" : "mx@s",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "ambix_rotator_o7_20230106.maxsnap",
+				"name" : "SceneRotator.maxsnap",
 				"bootpath" : "~/Documents/Max 8/Snapshots",
 				"patcherrelativepath" : "../../../../Snapshots",
 				"type" : "mx@s",

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -556,7 +556,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 344.0, 764.0, 78.0, 22.0 ],
+					"patching_rect" : [ 238.0, 735.0, 78.0, 22.0 ],
 					"text" : "r chargeFiles"
 				}
 
@@ -568,7 +568,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 464.0, 764.0, 100.0, 22.0 ],
+					"patching_rect" : [ 358.0, 735.0, 100.0, 22.0 ],
 					"text" : "sprintf %s%s"
 				}
 
@@ -2788,7 +2788,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 927.5, 295.702117919921875, 62.0, 22.0 ],
+					"patching_rect" : [ 945.0, 295.702117919921875, 62.0, 22.0 ],
 					"text" : "s testPath"
 				}
 
@@ -2800,7 +2800,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 927.5, 319.702117919921875, 57.0, 22.0 ],
+					"patching_rect" : [ 945.0, 319.702117919921875, 57.0, 22.0 ],
 					"text" : "s refPath"
 				}
 
@@ -2813,7 +2813,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 927.5, 264.0, 62.0, 22.0 ],
+					"patching_rect" : [ 945.0, 264.0, 62.0, 22.0 ],
 					"text" : "r refName"
 				}
 
@@ -2822,11 +2822,11 @@
 				"box" : 				{
 					"id" : "obj-47",
 					"maxclass" : "newobj",
-					"numinlets" : 2,
+					"numinlets" : 3,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 690.0, 300.0, 219.0, 22.0 ],
-					"text" : "combine folderPath refPath @triggers 1"
+					"patching_rect" : [ 690.0, 300.0, 247.0, 22.0 ],
+					"text" : "combine folderPath refPath .wav @triggers 1"
 				}
 
 			}
@@ -2838,7 +2838,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 927.5, 240.0, 67.0, 22.0 ],
+					"patching_rect" : [ 945.0, 240.0, 67.0, 22.0 ],
 					"text" : "r testName"
 				}
 
@@ -2860,11 +2860,11 @@
 				"box" : 				{
 					"id" : "obj-40",
 					"maxclass" : "newobj",
-					"numinlets" : 2,
+					"numinlets" : 3,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 690.0, 270.0, 221.0, 22.0 ],
-					"text" : "combine folderPath filePath @triggers 1"
+					"patching_rect" : [ 690.0, 270.0, 249.0, 22.0 ],
+					"text" : "combine folderPath filePath .wav @triggers 1"
 				}
 
 			}
@@ -2875,7 +2875,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 464.5, 788.0, 64.0, 22.0 ],
+					"patching_rect" : [ 358.5, 759.0, 64.0, 22.0 ],
 					"text" : "s refName"
 				}
 
@@ -2894,49 +2894,13 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-32",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 5,
-					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 464.5, 719.0, 192.0, 22.0 ],
-					"text" : "regexp _\\\\d+_ @substitute _1156_"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-29",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 5,
-					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 378.5, 677.0, 134.0, 22.0 ],
-					"text" : "regexp GaussLegendre"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-26",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 5,
-					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 153.0, 682.0, 96.0, 22.0 ],
-					"text" : "regexp Extremal"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-23",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 211.0, 719.0, 192.0, 22.0 ],
-					"text" : "regexp _\\\\d+_ @substitute _2312_"
+					"patching_rect" : [ 248.0, 684.0, 305.0, 22.0 ],
+					"text" : "regexp _[^\\\\W_]+_\\\\d+_\\\\d+[^\\\\W_]+_o7 @substitute %0"
 				}
 
 			}
@@ -4604,13 +4568,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-23", 0 ],
-					"source" : [ "obj-26", 3 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-265", 0 ],
 					"source" : [ "obj-262", 0 ]
 				}
@@ -4690,13 +4647,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-155", 0 ],
 					"source" : [ "obj-286", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-32", 0 ],
-					"source" : [ "obj-29", 3 ]
 				}
 
 			}
@@ -4790,13 +4740,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-79", 1 ],
-					"source" : [ "obj-32", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-16", 0 ],
 					"source" : [ "obj-33", 0 ]
 				}
@@ -4804,16 +4747,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-26", 0 ],
-					"order" : 1,
-					"source" : [ "obj-33", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-29", 0 ],
-					"order" : 0,
+					"destination" : [ "obj-23", 0 ],
 					"source" : [ "obj-33", 1 ]
 				}
 

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -4,7 +4,7 @@
 		"appversion" : 		{
 			"major" : 8,
 			"minor" : 5,
-			"revision" : 1,
+			"revision" : 2,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -40,6 +40,72 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-174",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 100.5, 751.0, 29.5, 22.0 ],
+					"text" : "_90"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-85",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 61.5, 780.0, 67.0, 22.0 ],
+					"text" : "jstrigger ('')"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-67",
+					"maxclass" : "newobj",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "", "", "" ],
+					"patching_rect" : [ 61.5, 724.0, 97.0, 22.0 ],
+					"text" : "routepass 0° 90°"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"align" : 1,
+					"arrow" : 0,
+					"bgcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"bgfillcolor_angle" : 270.0,
+					"bgfillcolor_autogradient" : 0.0,
+					"bgfillcolor_color" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"bgfillcolor_color1" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
+					"bgfillcolor_color2" : [ 0.2, 0.2, 0.2, 1.0 ],
+					"bgfillcolor_proportion" : 0.5,
+					"bgfillcolor_type" : "color",
+					"fontface" : 1,
+					"fontname" : "Tahoma",
+					"id" : "obj-31",
+					"items" : [ "0°", ",", "90°" ],
+					"maxclass" : "umenu",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "int", "", "" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 21.0, 692.0, 100.0, 23.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 75.0, 155.0, 155.0, 23.0 ],
+					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
+					"textjustification" : 1,
+					"varname" : "radius[1]"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"bgcolor" : [ 1.0, 1.0, 1.0, 0.0 ],
 					"fontface" : 1,
 					"fontname" : "Tahoma",
@@ -48,10 +114,10 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 70.5, 244.32220458984375, 168.0, 50.0 ],
+					"patching_rect" : [ 338.5, 226.0, 168.0, 50.0 ],
 					"presentation" : 1,
 					"presentation_linecount" : 2,
-					"presentation_rect" : [ 68.5, 242.82220458984375, 193.0, 35.0 ],
+					"presentation_rect" : [ 68.5, 283.517852783203125, 194.0, 35.0 ],
 					"text" : "Changer dossier contenant les fichiers uadio",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ]
 				}
@@ -70,7 +136,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 685.5, 24.0, 24.0, 24.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 42.5, 248.32220458984375, 24.0, 24.0 ]
+					"presentation_rect" : [ 42.5, 289.017852783203125, 24.0, 24.0 ]
 				}
 
 			}
@@ -121,7 +187,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 184.0, 144.0, 168.0, 21.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 20.5, 182.32220458984375, 20.0, 21.0 ],
+					"presentation_rect" : [ 20.5, 223.017852783203125, 20.0, 21.0 ],
 					"text" : "2.",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 2
@@ -139,7 +205,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 149.0, 114.0, 168.0, 21.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 20.5, 154.304351806640625, 20.0, 21.0 ],
+					"presentation_rect" : [ 20.5, 195.0, 20.0, 21.0 ],
 					"text" : "1.",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 2
@@ -158,7 +224,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 177.0, 142.0, 168.0, 35.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 68.5, 182.32220458984375, 193.0, 21.0 ],
+					"presentation_rect" : [ 68.5, 223.017852783203125, 193.0, 21.0 ],
 					"text" : "Lancer la séquence (espace)",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ]
 				}
@@ -175,7 +241,7 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 236.0, 137.0, 168.0, 21.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 68.5, 154.304351806640625, 168.0, 21.0 ],
+					"presentation_rect" : [ 68.5, 195.0, 168.0, 21.0 ],
 					"text" : "Charger les sons (entrée)",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ]
 				}
@@ -400,6 +466,24 @@
 									}
 
 								}
+, 								{
+									"filetype" : "C74Snapshot",
+									"version" : 2,
+									"minorversion" : 0,
+									"name" : "ambix_rotator_o7",
+									"origin" : "ambix_rotator_o7.dll",
+									"type" : "VST",
+									"subtype" : "AudioEffect",
+									"embed" : 0,
+									"fileref" : 									{
+										"name" : "ambix_rotator_o7",
+										"filename" : "ambix_rotator_o7_20230106.maxsnap",
+										"filepath" : "~/Documents/Max 8/Snapshots",
+										"filepos" : -1,
+										"snapshotfileid" : "3662b5ee41b36475e6be07309bfb4253"
+									}
+
+								}
  ]
 						}
 
@@ -460,7 +544,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 540.6383056640625, 304.017852783203125, 24.0, 24.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 42.5, 152.804351806640625, 24.0, 24.0 ]
+					"presentation_rect" : [ 42.5, 193.5, 24.0, 24.0 ]
 				}
 
 			}
@@ -472,7 +556,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 264.0, 780.0, 78.0, 22.0 ],
+					"patching_rect" : [ 344.0, 764.0, 78.0, 22.0 ],
 					"text" : "r chargeFiles"
 				}
 
@@ -484,7 +568,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 384.0, 780.0, 100.0, 22.0 ],
+					"patching_rect" : [ 464.0, 764.0, 100.0, 22.0 ],
 					"text" : "sprintf %s%s"
 				}
 
@@ -698,7 +782,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 493.5, 1436.6666259765625, 24.0, 24.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 237.5, 152.804351806640625, 24.0, 24.0 ],
+					"presentation_rect" : [ 237.5, 193.5, 24.0, 24.0 ],
 					"uncheckedcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ]
 				}
 
@@ -923,7 +1007,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 65.5, 1301.6666259765625, 24.0, 24.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 42.5, 180.82220458984375, 24.0, 24.0 ]
+					"presentation_rect" : [ 42.5, 221.517852783203125, 24.0, 24.0 ]
 				}
 
 			}
@@ -2278,7 +2362,7 @@
 						"snapshot" : 						{
 							"pluginname" : "BinauralDecoder.dll",
 							"plugindisplayname" : "BinauralDecoder",
-							"pluginsavedname" : "",
+							"pluginsavedname" : "C:/Program Files/Steinberg/VSTPlugins/IEM/BinauralDecoder.dll",
 							"pluginsaveduniqueid" : 0,
 							"version" : 1,
 							"isbank" : 0,
@@ -2300,7 +2384,7 @@
 									"snapshot" : 									{
 										"pluginname" : "BinauralDecoder.dll",
 										"plugindisplayname" : "BinauralDecoder",
-										"pluginsavedname" : "",
+										"pluginsavedname" : "C:/Program Files/Steinberg/VSTPlugins/IEM/BinauralDecoder.dll",
 										"pluginsaveduniqueid" : 0,
 										"version" : 1,
 										"isbank" : 0,
@@ -2310,28 +2394,10 @@
 ,
 									"fileref" : 									{
 										"name" : "BinauralDecoder",
-										"filename" : "BinauralDecoder_20221128.maxsnap",
+										"filename" : "BinauralDecoder.maxsnap",
 										"filepath" : "~/Documents/Max 8/Snapshots",
 										"filepos" : -1,
-										"snapshotfileid" : "cc078206632d422b61634b6fd3e0dc89"
-									}
-
-								}
-, 								{
-									"filetype" : "C74Snapshot",
-									"version" : 2,
-									"minorversion" : 0,
-									"name" : "BinauralDecoder",
-									"origin" : "BinauralDecoder.dll",
-									"type" : "VST",
-									"subtype" : "AudioEffect",
-									"embed" : 0,
-									"fileref" : 									{
-										"name" : "BinauralDecoder",
-										"filename" : "BinauralDecoder_20221125.maxsnap",
-										"filepath" : "~/Documents/Max 8/Snapshots",
-										"filepos" : -1,
-										"snapshotfileid" : "ea4ed89e4c96d925ea5039462ae31962"
+										"snapshotfileid" : "3030a234fa311c85b2ac4447d2543bb8"
 									}
 
 								}
@@ -2440,7 +2506,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 255.0, 654.0, 107.0, 22.0 ],
+					"patching_rect" : [ 335.0, 638.0, 107.0, 22.0 ],
 					"text" : "s resetFileLoading"
 				}
 
@@ -2809,7 +2875,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 384.5, 804.0, 64.0, 22.0 ],
+					"patching_rect" : [ 464.5, 788.0, 64.0, 22.0 ],
 					"text" : "s refName"
 				}
 
@@ -2821,7 +2887,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "bang" ],
-					"patching_rect" : [ 157.0, 623.0, 41.0, 22.0 ],
+					"patching_rect" : [ 237.0, 607.0, 41.0, 22.0 ],
 					"text" : "t s s b"
 				}
 
@@ -2833,20 +2899,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 384.5, 735.0, 192.0, 22.0 ],
+					"patching_rect" : [ 464.5, 719.0, 192.0, 22.0 ],
 					"text" : "regexp _\\\\d+_ @substitute _1156_"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-31",
-					"linecount" : 2,
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 5.0, 729.5, 122.0, 34.0 ],
-					"text" : "Extremal unmatched : gaussLegendre"
 				}
 
 			}
@@ -2857,7 +2911,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 298.5, 693.0, 134.0, 22.0 ],
+					"patching_rect" : [ 378.5, 677.0, 134.0, 22.0 ],
 					"text" : "regexp GaussLegendre"
 				}
 
@@ -2869,7 +2923,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 73.0, 698.0, 96.0, 22.0 ],
+					"patching_rect" : [ 153.0, 682.0, 96.0, 22.0 ],
 					"text" : "regexp Extremal"
 				}
 
@@ -2881,7 +2935,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 131.0, 735.0, 192.0, 22.0 ],
+					"patching_rect" : [ 211.0, 719.0, 192.0, 22.0 ],
 					"text" : "regexp _\\\\d+_ @substitute _2312_"
 				}
 
@@ -2929,7 +2983,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 157.0, 654.0, 69.0, 22.0 ],
+					"patching_rect" : [ 237.0, 638.0, 69.0, 22.0 ],
 					"text" : "s testName"
 				}
 
@@ -2942,20 +2996,20 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 157.0, 544.0, 24.0, 24.0 ]
+					"patching_rect" : [ 237.0, 523.0, 24.0, 24.0 ]
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"id" : "obj-4",
-					"linecount" : 3,
+					"linecount" : 2,
 					"maxclass" : "newobj",
-					"numinlets" : 10,
+					"numinlets" : 11,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 157.0, 571.0, 214.0, 50.0 ],
-					"text" : "combine quartet _ broadcastingstudio _ Extremal _ 64 _ 6cm _o7.wav @padding 0 0 0 0 0 0 4 0 0 0"
+					"patching_rect" : [ 237.0, 555.0, 337.0, 36.0 ],
+					"text" : "combine quartet _ broadcastingstudio _ Extremal _ 64 _ 6cm _o7 _90.wav @padding 0 0 0 0 0 0 4 0 0 0"
 				}
 
 			}
@@ -2982,7 +3036,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 21.0, 644.0, 100.0, 23.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 75.0, 124.304351806640625, 155.0, 23.0 ],
+					"presentation_rect" : [ 75.0, 130.0, 155.0, 23.0 ],
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 1,
 					"varname" : "radius"
@@ -3084,7 +3138,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 21.0, 592.0, 100.0, 23.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 75.0, 102.86956787109375, 155.0, 23.0 ],
+					"presentation_rect" : [ 75.0, 105.0, 155.0, 23.0 ],
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 1,
 					"varname" : "nMic"
@@ -3114,7 +3168,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 21.0, 300.0, 100.0, 23.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 75.0, 81.434783935546875, 155.0, 23.0 ],
+					"presentation_rect" : [ 75.0, 80.0, 155.0, 23.0 ],
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 1,
 					"varname" : "pattern"
@@ -3144,7 +3198,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 21.0, 271.2978515625, 100.0, 23.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 75.0, 60.0, 155.0, 23.0 ],
+					"presentation_rect" : [ 75.0, 55.0, 155.0, 23.0 ],
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 1,
 					"varname" : "room"
@@ -3174,7 +3228,7 @@
 					"parameter_enable" : 0,
 					"patching_rect" : [ 21.0, 242.595733642578125, 100.0, 23.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 75.0, 38.565216064453125, 155.0, 23.0 ],
+					"presentation_rect" : [ 75.0, 30.0, 155.0, 23.0 ],
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"textjustification" : 1,
 					"varname" : "source"
@@ -3949,6 +4003,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-4", 10 ],
+					"source" : [ "obj-174", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-176", 0 ],
 					"source" : [ "obj-175", 0 ]
 				}
@@ -4715,6 +4776,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-12", 0 ],
+					"source" : [ "obj-31", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-67", 0 ],
+					"source" : [ "obj-31", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-79", 1 ],
 					"source" : [ "obj-32", 0 ]
 				}
@@ -4978,6 +5053,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-174", 0 ],
+					"source" : [ "obj-67", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-85", 0 ],
+					"source" : [ "obj-67", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-77", 0 ],
 					"source" : [ "obj-68", 0 ]
 				}
@@ -5085,6 +5174,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-4", 10 ],
+					"source" : [ "obj-85", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-49", 0 ],
 					"source" : [ "obj-86", 0 ]
 				}
@@ -5180,14 +5276,7 @@
 		}
 ,
 		"dependency_cache" : [ 			{
-				"name" : "BinauralDecoder_20221125.maxsnap",
-				"bootpath" : "~/Documents/Max 8/Snapshots",
-				"patcherrelativepath" : "../../../../Snapshots",
-				"type" : "mx@s",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "BinauralDecoder_20221128.maxsnap",
+				"name" : "BinauralDecoder.maxsnap",
 				"bootpath" : "~/Documents/Max 8/Snapshots",
 				"patcherrelativepath" : "../../../../Snapshots",
 				"type" : "mx@s",
@@ -5195,6 +5284,13 @@
 			}
 , 			{
 				"name" : "ambix_rotator_o7.maxsnap",
+				"bootpath" : "~/Documents/Max 8/Snapshots",
+				"patcherrelativepath" : "../../../../Snapshots",
+				"type" : "mx@s",
+				"implicit" : 1
+			}
+, 			{
+				"name" : "ambix_rotator_o7_20230106.maxsnap",
 				"bootpath" : "~/Documents/Max 8/Snapshots",
 				"patcherrelativepath" : "../../../../Snapshots",
 				"type" : "mx@s",

--- a/testEcoute/testEcoute.maxpat
+++ b/testEcoute/testEcoute.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 1954.0, 81.0, 1212.0, 883.0 ],
+		"rect" : [ 1954.0, 81.0, 842.0, 883.0 ],
 		"bglocked" : 1,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -460,7 +460,7 @@
 					"presentation" : 1,
 					"presentation_linecount" : 2,
 					"presentation_rect" : [ 68.5, 283.517852783203125, 194.0, 35.0 ],
-					"text" : "Changer dossier contenant les fichiers uadio",
+					"text" : "Changer dossier contenant les fichiers audio",
 					"textcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ]
 				}
 
@@ -652,6 +652,8 @@
 			}
 , 			{
 				"box" : 				{
+					"coldcolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ],
+					"hotcolor" : [ 0.247058823529412, 0.305882352941176, 0.309803921568627, 1.0 ],
 					"id" : "obj-132",
 					"lastchannelcount" : 0,
 					"maxclass" : "live.gain~",
@@ -659,9 +661,32 @@
 					"numoutlets" : 5,
 					"orientation" : 1,
 					"outlettype" : [ "signal", "signal", "", "float", "list" ],
+					"overloadcolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
 					"parameter_enable" : 1,
 					"patching_rect" : [ 384.0, 1095.0, 136.0, 47.0 ],
+					"presentation" : 1,
+					"presentation_rect" : [ 84.5, 345.0, 136.0, 47.0 ],
 					"saved_attribute_attributes" : 					{
+						"slidercolor" : 						{
+							"expression" : ""
+						}
+,
+						"textcolor" : 						{
+							"expression" : ""
+						}
+,
+						"tribordercolor" : 						{
+							"expression" : ""
+						}
+,
+						"tricolor" : 						{
+							"expression" : ""
+						}
+,
+						"trioncolor" : 						{
+							"expression" : ""
+						}
+,
 						"valueof" : 						{
 							"parameter_initial" : [ 0.0 ],
 							"parameter_longname" : "live.gain~",
@@ -674,7 +699,13 @@
 
 					}
 ,
-					"varname" : "live.gain~"
+					"slidercolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
+					"textcolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ],
+					"tribordercolor" : [ 0.172549019607843, 0.211764705882353, 0.223529411764706, 1.0 ],
+					"tricolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ],
+					"trioncolor" : [ 0.862745098039216, 0.843137254901961, 0.788235294117647, 1.0 ],
+					"varname" : "live.gain~",
+					"warmcolor" : [ 0.635294117647059, 0.482352941176471, 0.36078431372549, 1.0 ]
 				}
 
 			}
@@ -750,7 +781,7 @@
 							"version" : 1,
 							"isbank" : 0,
 							"isbase64" : 1,
-							"blob" : "848.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.EVMjLgrv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxMtTiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHv3RN4bCLv.CL4fiLxfCM0PiMh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKvHSLv.CLvHyM1TiM0TSMwfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL1TCLv.CL0biLx.CM0fSN3HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HBLt.SL2.CLv.yM4DSMzjiM3HiMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsHiKy.CLv.yLvTSL2TyM3DiLh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HRKw3BNv.CLvLCL0DyM0bCNwHiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
+							"blob" : "849.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LPEVMjLgvv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBLtHSLv.CL1bSLyfiM2DCN2TiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKv.SNv.CLvXiL4PiL0.CM3fyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iKv.iLv.CLvjyLzXCLvfyLv.CNh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLt.SL3jSN4jyLzDSN1PyMxDyMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsDiKvPCLv.CN0PCM4HSL3bSMh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HhLtDyM4jSNxXyM0bCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
 						}
 ,
 						"snapshotlist" : 						{
@@ -772,7 +803,7 @@
 										"version" : 1,
 										"isbank" : 0,
 										"isbase64" : 1,
-										"blob" : "848.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................L.EVMjLgrv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzxMtTiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHv3RN4bCLv.CL4fiLxfCM0PiMh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKvHSLv.CLvHyM1TiM0TSMwfiHu3COPEjTA0DHoQVOhDWdh.hcgwVck0iHv3BL1TCLv.CL0biLx.CM0fSN3HxK9vCTAIUPMARZj0iHwomHfXWXrUWY8HBLt.SL2.CLv.yM4DSMzjiM3HiMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsHiKy.CLv.yLvTSL2TyM3DiLh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HRKw3BNv.CLvLCL0DyM0bCNwHiHu3COOM0PC8lalk1YfHUYiUVZ1UlbP8lbz0iHsDiHfLUYtQVYxkDT8HhHfLUYtQVYxA0axQWOhzRLh.xTk4FYkI2SSMTPjQlbkM2b8HxKSMVYtUlTuQWXz8lbuHBHSUlajUlbI4FckImcgwVOhDCLvHxK9vyKSMVYtUlTuQWXz8lb9.."
+										"blob" : "849.CMlaKA....fQPMDZ....AL0XR8F..P.A....A........................................LPEVMjLgvv....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOSMVYtUlTuQWXz8lbfzTZjkFQkYWZiUlSg0VY8HhHfzTZjkFQkYWZiU1TigVYsUVOh.iH9vCTAIUPMARZj0iHo4lckIGcPkFciglHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzEUcgQWYx4VZu4lHfXWXrUWY8HRLt.iHu3COPEjTA0DHoQVOhjla1UlbzI0arwlHfXWXrUWY8HBLt.iHu3COPEjTA0DHoQVOhjla1UlbzkUX2IBH1EFa0UVOh.iKvHxK9vCTAIUPMARZj0iHuIGYkI2TkQGco41Yh.hcgwVck0iHv3BLh7hO7.UPRETSfjFY8HBboQ2XnIBH1EFa0UVOhzBLtHSLv.CL1bSLyfiM2DCN2TiHu3COPEjTA0DHoQVOhD2ch.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRb3IBH1EFa0UVOh.iKv.SNv.CLvXiL4PiL0.CM3fyLh7hO7.UPRETSfjFY8HRb4IBH1EFa0UVOh.iKv.iLv.CLvjyLzXCLvfyLv.CNh7hO7.UPRETSfjFY8HRb5IBH1EFa0UVOhzBLt.SL3jSN4jyLzDSN1PyMxDyMh7hO7.UPRETSfjFY8HhbuwFah.hcgwVck0iHsDiKvPCLv.CN0PCM4HSL3bSMh7hO7.UPRETSfjFY8HhbuQWXzk1atMUYwUWYtMVYh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRcyU1TNMCQh.hcgwVck0iHw3BLh7hO7.UPRETSfjFY8HRdgcmHfXWXrUWY8HhLtDyM4jSNxXyM0bCNwHSMh7hO77zTCMzatYVZmAhTkMVYoYWYxA0axQWOhzRLh.xTk4FYkIWRP0iHh.xTk4FYkIGTuIGc8HRKwHBHSUlajUlbOM0PAQFYxU1by0iHuL0Xk4VYR8FcgQ2ax8hHfLUYtQVYxkjazUlb1EFa8HRLv.iHu3COuL0Xk4VYR8FcgQ2ax4C."
 									}
 ,
 									"fileref" : 									{


### PR DESCRIPTION
Le patcher de test d'écoute prend désormais en compte les nouveaux stimuli, avec possibilité de placer les sources à 90° sur le côté.