### PR TITLE
Corrige saut après refreshUrn

### DIFF
--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -5439,7 +5439,7 @@
 				"box" : 				{
 					"comment" : "",
 					"id" : "obj-96",
-					"index" : 1,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -7592,13 +7592,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-129", 0 ],
-					"source" : [ "obj-306", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-306", 1 ],
 					"source" : [ "obj-307", 0 ]
 				}
@@ -8145,6 +8138,15 @@
 
 			}
  ],
+		"dependency_cache" : [ 			{
+				"name" : "Reponses.txt",
+				"bootpath" : "~/Documents/Max 8/Projects/Manip Aliasing Spatial/Manip-Aliasing-Spatial/Manip/data",
+				"patcherrelativepath" : "../data",
+				"type" : "TEXT",
+				"implicit" : 1
+			}
+ ],
+		"autosave" : 0,
 		"styles" : [ 			{
 				"name" : "AudioStatus_Menu",
 				"default" : 				{


### PR DESCRIPTION
Le bang **begin** envoyé à chaque refreshUrn n'envoie le bang **ready** que lors du lancement du test : évite d'envoyer deux fois **ready** lors du _refreshUrn_ lié à un départ différé.

resolves #32 