### PR TITLE
Sauvegarde rotation t3

### DIFF
--- a/Manip/patchers/Main.maxpat
+++ b/Manip/patchers/Main.maxpat
@@ -11,7 +11,7 @@
 ,
 		"classnamespace" : "box",
 		"rect" : [ 1954.0, 81.0, 1212.0, 883.0 ],
-		"bglocked" : 0,
+		"bglocked" : 1,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
@@ -39,6 +39,30 @@
 		"subpatcher_template" : "",
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-205",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 870.0, 120.0, 77.0, 22.0 ],
+					"text" : "route symbol"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-194",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 5,
+					"outlettype" : [ "", "", "", "", "" ],
+					"patching_rect" : [ 870.0, 150.0, 137.0, 22.0 ],
+					"text" : "regexp \" \" @substitute _"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-190",
 					"maxclass" : "comment",
@@ -1791,7 +1815,7 @@
 									"presentation_rect" : [ 60.0, 165.0, 18.0, 50.0 ],
 									"shape" : 2,
 									"size" : 3,
-									"value" : 1
+									"value" : 0
 								}
 
 							}
@@ -2714,7 +2738,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "" ],
-					"patching_rect" : [ 750.0, 150.0, 31.0, 22.0 ],
+					"patching_rect" : [ 750.0, 135.0, 31.0, 22.0 ],
 					"text" : "t b s"
 				}
 
@@ -2726,7 +2750,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 750.0, 90.0, 129.0, 22.0 ],
+					"patching_rect" : [ 750.0, 75.0, 129.0, 22.0 ],
 					"text" : "symbol \"Prénom Nom\""
 				}
 
@@ -2740,7 +2764,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "bang", "bang" ],
-					"patching_rect" : [ 750.0, 120.0, 76.0, 22.0 ],
+					"patching_rect" : [ 750.0, 105.0, 76.0, 22.0 ],
 					"text" : "dialog Nom :"
 				}
 
@@ -2752,7 +2776,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 765.0, 180.0, 73.0, 22.0 ],
+					"patching_rect" : [ 870.0, 180.0, 73.0, 22.0 ],
 					"text" : "s userName"
 				}
 
@@ -2765,7 +2789,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 750.0, 60.0, 24.0, 24.0 ]
+					"patching_rect" : [ 750.0, 45.0, 24.0, 24.0 ]
 				}
 
 			}
@@ -3732,7 +3756,7 @@
 ,
 					"patching_rect" : [ 22.0, 523.0, 111.48529052734375, 110.0 ],
 					"presentation" : 1,
-					"presentation_rect" : [ 776.0, 334.0, 300.0, 345.0 ],
+					"presentation_rect" : [ 456.0, 306.0, 300.0, 345.0 ],
 					"varname" : "bP_main",
 					"viewvisibility" : 1
 				}
@@ -4962,6 +4986,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-56", 0 ],
+					"source" : [ "obj-194", 3 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-56", 0 ],
+					"source" : [ "obj-194", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-189", 0 ],
 					"source" : [ "obj-195", 0 ]
 				}
@@ -5027,6 +5065,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-202", 0 ],
 					"source" : [ "obj-203", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-194", 0 ],
+					"source" : [ "obj-205", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-194", 0 ],
+					"source" : [ "obj-205", 0 ]
 				}
 
 			}
@@ -5491,7 +5543,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-56", 0 ],
+					"destination" : [ "obj-205", 0 ],
 					"source" : [ "obj-84", 1 ]
 				}
 

--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -10,8 +10,8 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 38.0, 81.0, 842.0, 883.0 ],
-		"bglocked" : 0,
+		"rect" : [ 34.0, 81.0, 1212.0, 883.0 ],
+		"bglocked" : 1,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
@@ -40,86 +40,124 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
-					"id" : "obj-406",
-					"linecount" : 2,
-					"maxclass" : "comment",
+					"id" : "obj-349",
+					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 2415.0, 765.0, 90.0, 34.0 ],
-					"presentation_linecount" : 2,
-					"text" : "Période échantillons T3"
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 840.0, 81.0, 22.0 ],
+					"text" : "prepend write"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-405",
-					"linecount" : 2,
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 2460.0, 450.0, 90.0, 34.0 ],
-					"presentation_linecount" : 2,
-					"text" : "nombre échantillons T3"
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-340",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2550.0, 780.0, 71.0, 22.0 ],
+					"text" : "r userName"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-404",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 2265.0, 450.0, 90.0, 20.0 ],
-					"text" : "durée stimulus"
+					"id" : "obj-338",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 810.0, 139.0, 22.0 ],
+					"text" : "sprintf symout %s/%s.txt"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-402",
+					"id" : "obj-442",
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2415.0, 735.0, 165.0, 22.0 ],
-					"text" : "12.034"
+					"patching_rect" : [ 2460.0, 750.0, 71.0, 22.0 ],
+					"text" : "rotationTete"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-400",
+					"id" : "obj-421",
 					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 2,
-					"outlettype" : [ "float", "" ],
-					"patching_rect" : [ 2445.0, 675.0, 35.0, 22.0 ],
-					"text" : "timer"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-399",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2445.0, 600.0, 29.5, 22.0 ],
-					"text" : "+ 1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-398",
-					"maxclass" : "toggle",
 					"numinlets" : 1,
 					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"parameter_enable" : 0,
-					"patching_rect" : [ 2445.0, 570.0, 24.0, 24.0 ]
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 780.0, 77.0, 22.0 ],
+					"text" : "absolutepath"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-415",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 720.0, 89.0, 22.0 ],
+					"text" : "r writeHeadRot"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-407",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 5,
+					"outlettype" : [ "", "", "", "", "" ],
+					"patching_rect" : [ 2460.0, 660.0, 144.0, 22.0 ],
+					"text" : "regexp \" ,\" @substitute \\\\\\,"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-408",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 630.0, 55.0, 22.0 ],
+					"text" : "append \\,"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-406",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 600.0, 122.0, 22.0 ],
+					"text" : "r headRotationExport"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-403",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "cr" ],
+					"patching_rect" : [ 2280.0, 480.0, 35.0, 22.0 ],
+					"text" : "t b cr"
 				}
 
 			}
@@ -127,167 +165,223 @@
 				"box" : 				{
 					"id" : "obj-396",
 					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 2,
-					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 2445.0, 630.0, 42.0, 22.0 ],
-					"text" : "gate 2"
+					"numinlets" : 1,
+					"numoutlets" : 5,
+					"outlettype" : [ "", "", "", "", "" ],
+					"patching_rect" : [ 2280.0, 660.0, 144.0, 22.0 ],
+					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-395",
+					"id" : "obj-389",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "bang", "bang" ],
-					"patching_rect" : [ 2415.0, 540.0, 32.0, 22.0 ],
-					"text" : "t b b"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-386",
-					"maxclass" : "message",
-					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 450.0, 50.0, 22.0 ],
-					"text" : "2429."
+					"patching_rect" : [ 2280.0, 630.0, 55.0, 22.0 ],
+					"text" : "append \\,"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-384",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 2,
-					"outlettype" : [ "float", "" ],
-					"patching_rect" : [ 2370.0, 390.0, 35.0, 22.0 ],
-					"text" : "timer"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-381",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2552.0, 285.0, 59.0, 22.0 ],
-					"text" : "r endPlay"
-				}
-
-			}
-, 			{
-				"box" : 				{
+					"color" : [ 0.384313725490196, 0.627450980392157, 0.337254901960784, 1.0 ],
 					"id" : "obj-379",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 3,
-					"outlettype" : [ "bang", "bang", "int" ],
-					"patching_rect" : [ 2490.0, 314.0, 42.0, 22.0 ],
-					"text" : "t b b 0"
+					"outlettype" : [ "", "bang", "int" ],
+					"patching_rect" : [ 2280.0, 795.0, 40.0, 22.0 ],
+					"text" : "text"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-380",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2490.0, 285.0, 49.0, 22.0 ],
-					"text" : "r pause"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-378",
+					"id" : "obj-373",
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2432.0, 331.0, 32.0, 22.0 ],
-					"text" : "gate"
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2310.0, 570.0, 29.5, 22.0 ],
+					"text" : "- 1"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-377",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 3,
-					"outlettype" : [ "bang", "int", "int" ],
-					"patching_rect" : [ 2329.5, 326.0, 42.0, 22.0 ],
-					"text" : "t b 1 1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-374",
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-371",
 					"maxclass" : "newobj",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2329.5, 297.0, 62.0, 22.0 ],
-					"text" : "r playStim"
+					"patching_rect" : [ 2310.0, 540.0, 40.0, 22.0 ],
+					"text" : "r nVar"
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"id" : "obj-370",
-					"maxclass" : "message",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 2280.0, 600.0, 45.0, 22.0 ],
+					"text" : "zl.slice"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-365",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2220.0, 390.0, 91.0, 22.0 ],
+					"text" : "s writeHeadRot"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-364",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "int" ],
+					"patching_rect" : [ 2220.0, 300.0, 32.0, 22.0 ],
+					"text" : "t b 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-358",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2280.0, 450.0, 84.0, 22.0 ],
+					"text" : "r loadedComb"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-357",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2355.0, 390.0, 124.0, 22.0 ],
+					"text" : "s headRotationExport"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.847058823529412, 0.76078431372549, 0.337254901960784, 1.0 ],
+					"id" : "obj-356",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2280.0, 510.0, 47.0, 22.0 ],
+					"text" : "v comb"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-355",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2310.0, 300.0, 22.0, 22.0 ],
+					"text" : "t 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-354",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2280.0, 300.0, 22.0, 22.0 ],
+					"text" : "t 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-336",
+					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2415.0, 450.0, 50.0, 22.0 ],
-					"text" : "153"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-368",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2445.0, 401.0, 47.0, 22.0 ],
-					"text" : "v count"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-367",
-					"maxclass" : "button",
-					"numinlets" : 1,
-					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"parameter_enable" : 0,
-					"patching_rect" : [ 2445.0, 295.0, 24.0, 24.0 ]
+					"patching_rect" : [ 2280.0, 360.0, 56.0, 22.0 ],
+					"text" : "metro 20"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-330",
+					"color" : [ 0.847058823529412, 0.76078431372549, 0.337254901960784, 1.0 ],
+					"id" : "obj-334",
 					"maxclass" : "newobj",
-					"numinlets" : 5,
-					"numoutlets" : 4,
-					"outlettype" : [ "int", "", "", "int" ],
-					"patching_rect" : [ 2445.0, 366.0, 61.0, 22.0 ],
-					"text" : "counter"
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2355.0, 360.0, 89.0, 22.0 ],
+					"text" : "v headRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-381",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 240.0, 59.0, 22.0 ],
+					"text" : "r endPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-380",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2280.0, 240.0, 49.0, 22.0 ],
+					"text" : "r pause"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109803921568627, 0.482352941176471, 0.537254901960784, 1.0 ],
+					"id" : "obj-374",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2310.0, 270.0, 62.0, 22.0 ],
+					"text" : "r playStim"
 				}
 
 			}
@@ -299,7 +393,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2445.0, 255.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 315.0, 89.0, 22.0 ],
 					"text" : "r centeredQuat"
 				}
 
@@ -544,17 +638,6 @@
 					}
 ,
 					"text" : "p openBackup"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-321",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 2124.0, 700.0, 32.0, 22.0 ],
-					"text" : "print"
 				}
 
 			}
@@ -1543,7 +1626,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1785.0, 375.0, 95.0, 119.0 ],
+					"patching_rect" : [ 1785.0, 375.0, 101.0, 119.0 ],
 					"text" : "\"C:/Users/User/Documents/Max 8/Projects/Manip Aliasing Spatial/Manip-Aliasing-Spatial/Manip/data/Reponses.txt\""
 				}
 
@@ -3922,7 +4005,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 481.5819091796875, 960.0, 162.0, 22.0 ],
-					"text" : "courbe\\, 8"
+					"text" : "courbe 7"
 				}
 
 			}
@@ -4034,7 +4117,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 679.0, 214.0, 1212.0, 883.0 ],
+						"rect" : [ 38.0, 214.0, 1212.0, 883.0 ],
 						"bglocked" : 1,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -5820,7 +5903,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 417.0, 200.0, 1212.0, 883.0 ],
+						"rect" : [ 38.0, 200.0, 1212.0, 883.0 ],
 						"bglocked" : 1,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -8530,16 +8613,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-367", 0 ],
-					"order" : 0,
-					"source" : [ "obj-314", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-395", 0 ],
-					"order" : 1,
+					"destination" : [ "obj-334", 0 ],
 					"source" : [ "obj-314", 0 ]
 				}
 
@@ -8616,24 +8690,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-321", 0 ],
-					"order" : 0,
-					"source" : [ "obj-326", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-325", 0 ],
-					"order" : 1,
 					"source" : [ "obj-326", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-368", 0 ],
-					"source" : [ "obj-330", 0 ]
 				}
 
 			}
@@ -8660,6 +8718,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-357", 0 ],
+					"source" : [ "obj-334", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-326", 0 ],
 					"source" : [ "obj-335", 1 ]
 				}
@@ -8681,6 +8746,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-334", 0 ],
+					"source" : [ "obj-336", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-349", 0 ],
+					"source" : [ "obj-338", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-82", 0 ],
 					"source" : [ "obj-339", 0 ]
 				}
@@ -8690,6 +8769,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-13", 1 ],
 					"source" : [ "obj-34", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-338", 1 ],
+					"source" : [ "obj-340", 0 ]
 				}
 
 			}
@@ -8730,8 +8816,43 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-349", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-253", 0 ],
 					"source" : [ "obj-35", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-336", 0 ],
+					"source" : [ "obj-354", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-336", 0 ],
+					"source" : [ "obj-355", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-370", 0 ],
+					"source" : [ "obj-356", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-403", 0 ],
+					"source" : [ "obj-358", 0 ]
 				}
 
 			}
@@ -8796,15 +8917,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-378", 1 ],
-					"source" : [ "obj-367", 0 ]
+					"destination" : [ "obj-336", 0 ],
+					"source" : [ "obj-364", 1 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-370", 1 ],
-					"source" : [ "obj-368", 0 ]
+					"destination" : [ "obj-365", 0 ],
+					"source" : [ "obj-364", 0 ]
 				}
 
 			}
@@ -8817,6 +8938,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-389", 0 ],
+					"source" : [ "obj-370", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-373", 0 ],
+					"source" : [ "obj-371", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-41", 0 ],
 					"source" : [ "obj-372", 0 ]
 				}
@@ -8824,57 +8959,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-377", 0 ],
+					"destination" : [ "obj-370", 1 ],
+					"source" : [ "obj-373", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-355", 0 ],
 					"source" : [ "obj-374", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-330", 2 ],
-					"source" : [ "obj-377", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-378", 0 ],
-					"source" : [ "obj-377", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-384", 0 ],
-					"source" : [ "obj-377", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-330", 0 ],
-					"source" : [ "obj-378", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-368", 0 ],
-					"source" : [ "obj-379", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-378", 0 ],
-					"source" : [ "obj-379", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-384", 1 ],
-					"source" : [ "obj-379", 0 ]
 				}
 
 			}
@@ -8887,22 +8980,22 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
+					"destination" : [ "obj-354", 0 ],
 					"source" : [ "obj-380", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
+					"destination" : [ "obj-364", 0 ],
 					"source" : [ "obj-381", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-386", 1 ],
-					"source" : [ "obj-384", 0 ]
+					"destination" : [ "obj-396", 0 ],
+					"source" : [ "obj-389", 0 ]
 				}
 
 			}
@@ -8924,43 +9017,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-396", 1 ],
-					"source" : [ "obj-395", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-398", 0 ],
-					"source" : [ "obj-395", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-400", 1 ],
-					"source" : [ "obj-396", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-400", 0 ],
+					"destination" : [ "obj-379", 0 ],
 					"source" : [ "obj-396", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-399", 0 ],
-					"source" : [ "obj-398", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-396", 0 ],
-					"source" : [ "obj-399", 0 ]
 				}
 
 			}
@@ -9003,8 +9061,36 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-402", 1 ],
-					"source" : [ "obj-400", 0 ]
+					"destination" : [ "obj-356", 0 ],
+					"source" : [ "obj-403", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-403", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-408", 0 ],
+					"source" : [ "obj-406", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-407", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-407", 0 ],
+					"source" : [ "obj-408", 0 ]
 				}
 
 			}
@@ -9017,8 +9103,29 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-442", 0 ],
+					"source" : [ "obj-415", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-338", 0 ],
+					"source" : [ "obj-421", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-164", 0 ],
 					"source" : [ "obj-43", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-421", 0 ],
+					"source" : [ "obj-442", 0 ]
 				}
 
 			}

--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 81.0, 1212.0, 883.0 ],
+		"rect" : [ 38.0, 81.0, 1212.0, 883.0 ],
 		"bglocked" : 1,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -40,12 +40,111 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-363",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 855.0, 115.0, 22.0 ],
+					"text" : "r saveHeadRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-353",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 885.0, 32.0, 22.0 ],
+					"text" : "gate"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-352",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "cr" ],
+					"patching_rect" : [ 2220.0, 825.0, 29.0, 22.0 ],
+					"text" : "thru"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-350",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2460.0, 285.0, 117.0, 22.0 ],
+					"text" : "s saveHeadRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-342",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2550.0, 255.0, 22.0, 22.0 ],
+					"text" : "t 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-341",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2460.0, 255.0, 22.0, 22.0 ],
+					"text" : "t 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-337",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2550.0, 225.0, 55.0, 22.0 ],
+					"text" : "r runTest"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-330",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2460.0, 225.0, 86.0, 22.0 ],
+					"text" : "r entrainement"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-349",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 840.0, 81.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 930.0, 81.0, 22.0 ],
 					"text" : "prepend write"
 				}
 
@@ -58,7 +157,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2550.0, 780.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2490.0, 870.0, 71.0, 22.0 ],
 					"text" : "r userName"
 				}
 
@@ -70,7 +169,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 810.0, 139.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 900.0, 139.0, 22.0 ],
 					"text" : "sprintf symout %s/%s.txt"
 				}
 
@@ -82,7 +181,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 750.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 840.0, 71.0, 22.0 ],
 					"text" : "rotationTete"
 				}
 
@@ -94,7 +193,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 780.0, 77.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 870.0, 77.0, 22.0 ],
 					"text" : "absolutepath"
 				}
 
@@ -107,7 +206,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 720.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 810.0, 89.0, 22.0 ],
 					"text" : "r writeHeadRot"
 				}
 
@@ -119,7 +218,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2460.0, 660.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 750.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -131,7 +230,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 630.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 720.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -144,7 +243,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 600.0, 122.0, 22.0 ],
+					"patching_rect" : [ 2400.0, 690.0, 122.0, 22.0 ],
 					"text" : "r headRotationExport"
 				}
 
@@ -156,7 +255,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "cr" ],
-					"patching_rect" : [ 2280.0, 480.0, 35.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 570.0, 35.0, 22.0 ],
 					"text" : "t b cr"
 				}
 
@@ -168,7 +267,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2280.0, 660.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 750.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -180,7 +279,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2280.0, 630.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 720.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -193,7 +292,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "bang", "int" ],
-					"patching_rect" : [ 2280.0, 795.0, 40.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 915.0, 40.0, 22.0 ],
 					"text" : "text"
 				}
 
@@ -205,7 +304,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2310.0, 570.0, 29.5, 22.0 ],
+					"patching_rect" : [ 2250.0, 660.0, 29.5, 22.0 ],
 					"text" : "- 1"
 				}
 
@@ -218,7 +317,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2310.0, 540.0, 40.0, 22.0 ],
+					"patching_rect" : [ 2250.0, 630.0, 40.0, 22.0 ],
 					"text" : "r nVar"
 				}
 
@@ -230,7 +329,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 2280.0, 600.0, 45.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 690.0, 45.0, 22.0 ],
 					"text" : "zl.slice"
 				}
 
@@ -242,7 +341,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2220.0, 390.0, 91.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 375.0, 91.0, 22.0 ],
 					"text" : "s writeHeadRot"
 				}
 
@@ -267,7 +366,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2280.0, 450.0, 84.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 540.0, 84.0, 22.0 ],
 					"text" : "r loadedComb"
 				}
 
@@ -279,7 +378,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2355.0, 390.0, 124.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 375.0, 124.0, 22.0 ],
 					"text" : "s headRotationExport"
 				}
 
@@ -292,7 +391,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2280.0, 510.0, 47.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 600.0, 47.0, 22.0 ],
 					"text" : "v comb"
 				}
 
@@ -328,7 +427,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 2280.0, 360.0, 56.0, 22.0 ],
+					"patching_rect" : [ 2280.0, 345.0, 56.0, 22.0 ],
 					"text" : "metro 20"
 				}
 
@@ -341,7 +440,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 360.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 345.0, 89.0, 22.0 ],
 					"text" : "v headRotation"
 				}
 
@@ -8697,6 +8796,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-341", 0 ],
+					"source" : [ "obj-330", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-332", 0 ],
 					"source" : [ "obj-331", 0 ]
 				}
@@ -8753,6 +8859,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-342", 0 ],
+					"source" : [ "obj-337", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-349", 0 ],
 					"source" : [ "obj-338", 0 ]
 				}
@@ -8776,6 +8889,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-338", 1 ],
 					"source" : [ "obj-340", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-350", 0 ],
+					"source" : [ "obj-341", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-350", 0 ],
+					"source" : [ "obj-342", 0 ]
 				}
 
 			}
@@ -8816,7 +8943,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
+					"destination" : [ "obj-352", 0 ],
 					"source" : [ "obj-349", 0 ]
 				}
 
@@ -8825,6 +8952,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-253", 0 ],
 					"source" : [ "obj-35", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-353", 1 ],
+					"source" : [ "obj-352", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-353", 0 ]
 				}
 
 			}
@@ -8912,6 +9053,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-359", 0 ],
 					"source" : [ "obj-362", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-353", 0 ],
+					"source" : [ "obj-363", 0 ]
 				}
 
 			}
@@ -9017,7 +9165,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
+					"destination" : [ "obj-352", 0 ],
 					"source" : [ "obj-396", 0 ]
 				}
 
@@ -9061,15 +9209,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-356", 0 ],
-					"source" : [ "obj-403", 0 ]
+					"destination" : [ "obj-352", 0 ],
+					"source" : [ "obj-403", 1 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
-					"source" : [ "obj-403", 1 ]
+					"destination" : [ "obj-356", 0 ],
+					"source" : [ "obj-403", 0 ]
 				}
 
 			}
@@ -9082,7 +9230,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-379", 0 ],
+					"destination" : [ "obj-352", 0 ],
 					"source" : [ "obj-407", 0 ]
 				}
 

--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -10,8 +10,8 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 38.0, 81.0, 1212.0, 883.0 ],
-		"bglocked" : 1,
+		"rect" : [ 38.0, 81.0, 842.0, 883.0 ],
+		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
@@ -39,6 +39,30 @@
 		"subpatcher_template" : "ManipAliasingSpatial",
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-429",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2265.0, 1170.0, 55.0, 22.0 ],
+					"text" : "append \\,"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-376",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2265.0, 1200.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
 					"id" : "obj-375",
@@ -158,7 +182,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2220.0, 1710.0, 95.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1755.0, 95.0, 22.0 ],
 					"text" : "s toRotationText"
 				}
 
@@ -170,7 +194,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1680.0, 81.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1725.0, 81.0, 22.0 ],
 					"text" : "prepend write"
 				}
 
@@ -183,7 +207,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2310.0, 1620.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2310.0, 1665.0, 71.0, 22.0 ],
 					"text" : "r userName"
 				}
 
@@ -195,7 +219,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1650.0, 139.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1695.0, 139.0, 22.0 ],
 					"text" : "sprintf symout %s/%s.txt"
 				}
 
@@ -207,7 +231,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1590.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1635.0, 71.0, 22.0 ],
 					"text" : "rotationTete"
 				}
 
@@ -219,7 +243,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1620.0, 77.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1665.0, 77.0, 22.0 ],
 					"text" : "absolutepath"
 				}
 
@@ -232,7 +256,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1560.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1605.0, 89.0, 22.0 ],
 					"text" : "r writeHeadRot"
 				}
 
@@ -318,7 +342,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2295.0, 1305.0, 95.0, 22.0 ],
+					"patching_rect" : [ 2295.0, 1350.0, 95.0, 22.0 ],
 					"text" : "s toRotationText"
 				}
 
@@ -330,7 +354,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2430.0, 1485.0, 95.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1530.0, 95.0, 22.0 ],
 					"text" : "s toRotationText"
 				}
 
@@ -342,7 +366,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2220.0, 1485.0, 95.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1530.0, 95.0, 22.0 ],
 					"text" : "s toRotationText"
 				}
 
@@ -463,7 +487,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2430.0, 1305.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1350.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -475,7 +499,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2430.0, 1275.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1320.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -488,7 +512,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2430.0, 1245.0, 122.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1290.0, 122.0, 22.0 ],
 					"text" : "r headRotationExport"
 				}
 
@@ -500,7 +524,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "cr" ],
-					"patching_rect" : [ 2220.0, 1275.0, 35.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1320.0, 35.0, 22.0 ],
 					"text" : "t b cr"
 				}
 
@@ -512,7 +536,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2220.0, 1455.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1500.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -524,7 +548,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1425.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1470.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -549,7 +573,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2250.0, 1365.0, 29.5, 22.0 ],
+					"patching_rect" : [ 2250.0, 1410.0, 29.5, 22.0 ],
 					"text" : "- 1"
 				}
 
@@ -562,7 +586,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2250.0, 1335.0, 40.0, 22.0 ],
+					"patching_rect" : [ 2250.0, 1380.0, 40.0, 22.0 ],
 					"text" : "r nVar"
 				}
 
@@ -574,7 +598,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 2220.0, 1395.0, 45.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1440.0, 45.0, 22.0 ],
 					"text" : "zl.slice"
 				}
 
@@ -611,7 +635,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1245.0, 84.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1290.0, 84.0, 22.0 ],
 					"text" : "r loadedComb"
 				}
 
@@ -623,7 +647,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2355.0, 1140.0, 124.0, 22.0 ],
+					"patching_rect" : [ 2385.0, 1140.0, 124.0, 22.0 ],
 					"text" : "s headRotationExport"
 				}
 
@@ -636,7 +660,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 1305.0, 47.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1350.0, 47.0, 22.0 ],
 					"text" : "v comb"
 				}
 
@@ -648,7 +672,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2310.0, 1065.0, 22.0, 22.0 ],
+					"patching_rect" : [ 2325.0, 1065.0, 22.0, 22.0 ],
 					"text" : "t 1"
 				}
 
@@ -658,10 +682,10 @@
 					"id" : "obj-354",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2280.0, 1065.0, 22.0, 22.0 ],
-					"text" : "t 0"
+					"numoutlets" : 2,
+					"outlettype" : [ "next", "int" ],
+					"patching_rect" : [ 2265.0, 1065.0, 48.0, 22.0 ],
+					"text" : "t next 0"
 				}
 
 			}
@@ -685,7 +709,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 1110.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2385.0, 1110.0, 89.0, 22.0 ],
 					"text" : "v headRotation"
 				}
 
@@ -711,7 +735,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2280.0, 1005.0, 49.0, 22.0 ],
+					"patching_rect" : [ 2265.0, 1035.0, 49.0, 22.0 ],
 					"text" : "r pause"
 				}
 
@@ -724,7 +748,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2310.0, 1035.0, 62.0, 22.0 ],
+					"patching_rect" : [ 2325.0, 1035.0, 62.0, 22.0 ],
 					"text" : "r playStim"
 				}
 
@@ -737,7 +761,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 1080.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2385.0, 1080.0, 89.0, 22.0 ],
 					"text" : "r centeredQuat"
 				}
 
@@ -3629,6 +3653,7 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-84",
+									"int" : 1,
 									"maxclass" : "gswitch",
 									"numinlets" : 3,
 									"numoutlets" : 1,
@@ -4349,7 +4374,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 481.5819091796875, 960.0, 162.0, 22.0 ],
-					"text" : "courbe 7"
+					"text" : "courbe\\, 8"
 				}
 
 			}
@@ -6779,7 +6804,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2310.0, 1530.0, 195.0, 20.0 ],
+					"patching_rect" : [ 2310.0, 1575.0, 195.0, 20.0 ],
 					"suppressinlet" : 1,
 					"text" : "Exporte le fichier texte",
 					"textjustification" : 1
@@ -6809,7 +6834,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2310.0, 1185.0, 195.0, 48.0 ],
+					"patching_rect" : [ 2310.0, 1230.0, 195.0, 48.0 ],
 					"suppressinlet" : 1,
 					"text" : "Concatène l'orientation à la suite des niveaux des variables et des orientations précédentes",
 					"textjustification" : 1
@@ -6871,7 +6896,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2205.0, 210.0, 405.0, 1530.0 ],
+					"patching_rect" : [ 2205.0, 210.0, 405.0, 1575.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -9314,6 +9339,13 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-336", 0 ],
+					"source" : [ "obj-354", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-429", 0 ],
 					"source" : [ "obj-354", 0 ]
 				}
 
@@ -9686,6 +9718,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-388", 0 ],
 					"source" : [ "obj-426", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-376", 0 ],
+					"source" : [ "obj-429", 0 ]
 				}
 
 			}

--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -41,73 +41,25 @@
 		"boxes" : [ 			{
 				"box" : 				{
 					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-363",
+					"id" : "obj-375",
 					"maxclass" : "newobj",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 855.0, 115.0, 22.0 ],
-					"text" : "r saveHeadRotation"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-353",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 885.0, 32.0, 22.0 ],
-					"text" : "gate"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-352",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "cr" ],
-					"patching_rect" : [ 2220.0, 825.0, 29.0, 22.0 ],
-					"text" : "thru"
+					"patching_rect" : [ 2220.0, 465.0, 103.0, 22.0 ],
+					"text" : "r loadRotationFile"
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
-					"id" : "obj-350",
+					"id" : "obj-369",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2460.0, 285.0, 117.0, 22.0 ],
-					"text" : "s saveHeadRotation"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-342",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2550.0, 255.0, 22.0, 22.0 ],
-					"text" : "t 1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-341",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2460.0, 255.0, 22.0, 22.0 ],
-					"text" : "t 0"
+					"patching_rect" : [ 2430.0, 360.0, 105.0, 22.0 ],
+					"text" : "s loadRotationFile"
 				}
 
 			}
@@ -119,21 +71,95 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2550.0, 225.0, 55.0, 22.0 ],
-					"text" : "r runTest"
+					"patching_rect" : [ 2220.0, 810.0, 90.0, 22.0 ],
+					"text" : "r checkSession"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-330",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2445.0, 330.0, 92.0, 22.0 ],
+					"text" : "s checkSession"
 				}
 
 			}
 , 			{
 				"box" : 				{
 					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
-					"id" : "obj-330",
+					"id" : "obj-368",
 					"maxclass" : "newobj",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2460.0, 225.0, 86.0, 22.0 ],
-					"text" : "r entrainement"
+					"patching_rect" : [ 2340.0, 525.0, 71.0, 22.0 ],
+					"text" : "r userName"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-366",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 2220.0, 870.0, 34.0, 22.0 ],
+					"text" : "sel 2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.847058823529412, 0.76078431372549, 0.337254901960784, 1.0 ],
+					"id" : "obj-352",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 840.0, 59.0, 22.0 ],
+					"text" : "v session"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-344",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "bang" ],
+					"patching_rect" : [ 2430.0, 300.0, 32.0, 22.0 ],
+					"text" : "t b b"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-321",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2430.0, 270.0, 60.0, 22.0 ],
+					"text" : "r fileRead"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-399",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2220.0, 1710.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
 				}
 
 			}
@@ -144,7 +170,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 930.0, 81.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1680.0, 81.0, 22.0 ],
 					"text" : "prepend write"
 				}
 
@@ -157,7 +183,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2490.0, 870.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2310.0, 1620.0, 71.0, 22.0 ],
 					"text" : "r userName"
 				}
 
@@ -169,7 +195,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 900.0, 139.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1650.0, 139.0, 22.0 ],
 					"text" : "sprintf symout %s/%s.txt"
 				}
 
@@ -181,7 +207,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 840.0, 71.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1590.0, 71.0, 22.0 ],
 					"text" : "rotationTete"
 				}
 
@@ -193,7 +219,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 870.0, 77.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1620.0, 77.0, 22.0 ],
 					"text" : "absolutepath"
 				}
 
@@ -206,8 +232,227 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 810.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1560.0, 89.0, 22.0 ],
 					"text" : "r writeHeadRot"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-426",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 615.0, 77.0, 22.0 ],
+					"text" : "absolutepath"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-422",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 675.0, 80.0, 22.0 ],
+					"text" : "prepend read"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-417",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2220.0, 705.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-416",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 2220.0, 585.0, 31.0, 22.0 ],
+					"text" : "t s s"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.847058823529412, 0.76078431372549, 0.337254901960784, 1.0 ],
+					"id" : "obj-414",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2310.0, 615.0, 102.0, 22.0 ],
+					"text" : "v rotationFilePath"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-398",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 270.0, 93.0, 22.0 ],
+					"text" : "r toRotationText"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-397",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2295.0, 1305.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-395",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2430.0, 1485.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-394",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2220.0, 1485.0, 95.0, 22.0 ],
+					"text" : "s toRotationText"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-388",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 2220.0, 645.0, 74.0, 22.0 ],
+					"text" : "sel notfound"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-385",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 525.0, 77.0, 22.0 ],
+					"text" : "absolutepath"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-367",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 495.0, 71.0, 22.0 ],
+					"text" : "rotationTete"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-351",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 555.0, 139.0, 22.0 ],
+					"text" : "sprintf symout %s/%s.txt"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-363",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 300.0, 115.0, 22.0 ],
+					"text" : "r saveHeadRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-353",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2220.0, 330.0, 32.0, 22.0 ],
+					"text" : "gate"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.630609, 0.277737, 0.179169, 1.0 ],
+					"id" : "obj-350",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2220.0, 930.0, 117.0, 22.0 ],
+					"text" : "s saveHeadRotation"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-342",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2250.0, 900.0, 22.0, 22.0 ],
+					"text" : "t 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-341",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2220.0, 900.0, 22.0, 22.0 ],
+					"text" : "t 1"
 				}
 
 			}
@@ -218,7 +463,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2400.0, 750.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1305.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -230,7 +475,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 720.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1275.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -243,7 +488,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2400.0, 690.0, 122.0, 22.0 ],
+					"patching_rect" : [ 2430.0, 1245.0, 122.0, 22.0 ],
 					"text" : "r headRotationExport"
 				}
 
@@ -255,7 +500,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "cr" ],
-					"patching_rect" : [ 2220.0, 570.0, 35.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1275.0, 35.0, 22.0 ],
 					"text" : "t b cr"
 				}
 
@@ -267,7 +512,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 5,
 					"outlettype" : [ "", "", "", "", "" ],
-					"patching_rect" : [ 2220.0, 750.0, 144.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1455.0, 144.0, 22.0 ],
 					"text" : "regexp \" ,\" @substitute \\\\\\,"
 				}
 
@@ -279,7 +524,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 720.0, 55.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1425.0, 55.0, 22.0 ],
 					"text" : "append \\,"
 				}
 
@@ -292,7 +537,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "bang", "int" ],
-					"patching_rect" : [ 2220.0, 915.0, 40.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 360.0, 40.0, 22.0 ],
 					"text" : "text"
 				}
 
@@ -304,7 +549,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2250.0, 660.0, 29.5, 22.0 ],
+					"patching_rect" : [ 2250.0, 1365.0, 29.5, 22.0 ],
 					"text" : "- 1"
 				}
 
@@ -317,7 +562,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2250.0, 630.0, 40.0, 22.0 ],
+					"patching_rect" : [ 2250.0, 1335.0, 40.0, 22.0 ],
 					"text" : "r nVar"
 				}
 
@@ -329,7 +574,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 2220.0, 690.0, 45.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1395.0, 45.0, 22.0 ],
 					"text" : "zl.slice"
 				}
 
@@ -341,7 +586,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2220.0, 375.0, 91.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1140.0, 91.0, 22.0 ],
 					"text" : "s writeHeadRot"
 				}
 
@@ -353,7 +598,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "int" ],
-					"patching_rect" : [ 2220.0, 300.0, 32.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1065.0, 32.0, 22.0 ],
 					"text" : "t b 0"
 				}
 
@@ -366,7 +611,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 540.0, 84.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1245.0, 84.0, 22.0 ],
 					"text" : "r loadedComb"
 				}
 
@@ -378,7 +623,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2355.0, 375.0, 124.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 1140.0, 124.0, 22.0 ],
 					"text" : "s headRotationExport"
 				}
 
@@ -391,7 +636,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 600.0, 47.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1305.0, 47.0, 22.0 ],
 					"text" : "v comb"
 				}
 
@@ -403,7 +648,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2310.0, 300.0, 22.0, 22.0 ],
+					"patching_rect" : [ 2310.0, 1065.0, 22.0, 22.0 ],
 					"text" : "t 1"
 				}
 
@@ -415,7 +660,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 2280.0, 300.0, 22.0, 22.0 ],
+					"patching_rect" : [ 2280.0, 1065.0, 22.0, 22.0 ],
 					"text" : "t 0"
 				}
 
@@ -427,7 +672,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 2280.0, 345.0, 56.0, 22.0 ],
+					"patching_rect" : [ 2280.0, 1110.0, 56.0, 22.0 ],
 					"text" : "metro 20"
 				}
 
@@ -440,7 +685,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 345.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 1110.0, 89.0, 22.0 ],
 					"text" : "v headRotation"
 				}
 
@@ -453,7 +698,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2220.0, 240.0, 59.0, 22.0 ],
+					"patching_rect" : [ 2220.0, 1005.0, 59.0, 22.0 ],
 					"text" : "r endPlay"
 				}
 
@@ -466,7 +711,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2280.0, 240.0, 49.0, 22.0 ],
+					"patching_rect" : [ 2280.0, 1005.0, 49.0, 22.0 ],
 					"text" : "r pause"
 				}
 
@@ -479,7 +724,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2310.0, 270.0, 62.0, 22.0 ],
+					"patching_rect" : [ 2310.0, 1035.0, 62.0, 22.0 ],
 					"text" : "r playStim"
 				}
 
@@ -492,7 +737,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 2355.0, 315.0, 89.0, 22.0 ],
+					"patching_rect" : [ 2355.0, 1080.0, 89.0, 22.0 ],
 					"text" : "r centeredQuat"
 				}
 
@@ -6530,13 +6775,87 @@
 , 			{
 				"box" : 				{
 					"background" : 1,
+					"id" : "obj-439",
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2310.0, 1530.0, 195.0, 20.0 ],
+					"suppressinlet" : 1,
+					"text" : "Exporte le fichier texte",
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-401",
+					"linecount" : 3,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2310.0, 405.0, 198.0, 48.0 ],
+					"suppressinlet" : 1,
+					"text" : "Créée/Charge le fichier d'export de l'orientation du headTracker\n(1 par participant)",
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-400",
+					"linecount" : 3,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2310.0, 1185.0, 195.0, 48.0 ],
+					"suppressinlet" : 1,
+					"text" : "Concatène l'orientation à la suite des niveaux des variables et des orientations précédentes",
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-393",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2310.0, 960.0, 195.0, 34.0 ],
+					"suppressinlet" : 1,
+					"text" : "Envoie l'orientation au fichier texte d'export",
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-390",
+					"linecount" : 3,
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2310.0, 750.0, 195.0, 48.0 ],
+					"suppressinlet" : 1,
+					"text" : "Active la sauvegarde de l'orientation de la tête pour les sessions test",
+					"textjustification" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
 					"id" : "obj-391",
 					"maxclass" : "comment",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2205.0, 210.0, 195.0, 20.0 ],
+					"patching_rect" : [ 2205.0, 210.0, 210.0, 20.0 ],
 					"suppressinlet" : 1,
-					"text" : "Exporte la rotation du HeadTracker"
+					"text" : "Exporte l'orientation du HeadTracker"
 				}
 
 			}
@@ -6552,7 +6871,7 @@
 					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 2205.0, 210.0, 420.0, 960.0 ],
+					"patching_rect" : [ 2205.0, 210.0, 405.0, 1530.0 ],
 					"proportion" : 0.5,
 					"prototypename" : "backgroundPanel"
 				}
@@ -7354,7 +7673,9 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-66", 0 ],
-					"source" : [ "obj-132", 0 ]
+					"source" : [ "obj-132", 0 ],
+					"watchpoint_flags" : 5,
+					"watchpoint_id" : 1
 				}
 
 			}
@@ -8768,6 +9089,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-344", 0 ],
+					"source" : [ "obj-321", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-324", 0 ],
 					"source" : [ "obj-323", 0 ]
 				}
@@ -8791,13 +9119,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-325", 0 ],
 					"source" : [ "obj-326", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-341", 0 ],
-					"source" : [ "obj-330", 0 ]
 				}
 
 			}
@@ -8859,7 +9180,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-342", 0 ],
+					"destination" : [ "obj-352", 0 ],
 					"source" : [ "obj-337", 0 ]
 				}
 
@@ -8915,6 +9236,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-330", 0 ],
+					"source" : [ "obj-344", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-369", 0 ],
+					"source" : [ "obj-344", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-348", 0 ],
 					"source" : [ "obj-345", 0 ]
 				}
@@ -8943,7 +9278,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-352", 0 ],
+					"destination" : [ "obj-399", 0 ],
 					"source" : [ "obj-349", 0 ]
 				}
 
@@ -8957,7 +9292,14 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-353", 1 ],
+					"destination" : [ "obj-416", 0 ],
+					"source" : [ "obj-351", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-366", 0 ],
 					"source" : [ "obj-352", 0 ]
 				}
 
@@ -9079,6 +9421,34 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-341", 0 ],
+					"source" : [ "obj-366", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-342", 0 ],
+					"source" : [ "obj-366", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-385", 0 ],
+					"source" : [ "obj-367", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-351", 1 ],
+					"source" : [ "obj-368", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-80", 0 ],
 					"source" : [ "obj-37", 0 ]
 				}
@@ -9121,6 +9491,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-367", 0 ],
+					"source" : [ "obj-375", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-41", 0 ],
 					"source" : [ "obj-38", 0 ]
 				}
@@ -9137,6 +9514,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-364", 0 ],
 					"source" : [ "obj-381", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-351", 0 ],
+					"source" : [ "obj-385", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-422", 0 ],
+					"source" : [ "obj-388", 1 ]
 				}
 
 			}
@@ -9165,8 +9556,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-352", 0 ],
+					"destination" : [ "obj-394", 0 ],
 					"source" : [ "obj-396", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-353", 1 ],
+					"source" : [ "obj-398", 0 ]
 				}
 
 			}
@@ -9209,15 +9607,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-352", 0 ],
-					"source" : [ "obj-403", 1 ]
+					"destination" : [ "obj-356", 0 ],
+					"source" : [ "obj-403", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-356", 0 ],
-					"source" : [ "obj-403", 0 ]
+					"destination" : [ "obj-397", 0 ],
+					"source" : [ "obj-403", 1 ]
 				}
 
 			}
@@ -9230,7 +9628,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-352", 0 ],
+					"destination" : [ "obj-395", 0 ],
 					"source" : [ "obj-407", 0 ]
 				}
 
@@ -9258,8 +9656,36 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-414", 0 ],
+					"source" : [ "obj-416", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-426", 0 ],
+					"source" : [ "obj-416", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-338", 0 ],
 					"source" : [ "obj-421", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-417", 0 ],
+					"source" : [ "obj-422", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-388", 0 ],
+					"source" : [ "obj-426", 0 ]
 				}
 
 			}
@@ -9392,7 +9818,9 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-53", 0 ],
-					"source" : [ "obj-62", 0 ]
+					"source" : [ "obj-62", 0 ],
+					"watchpoint_flags" : 5,
+					"watchpoint_id" : 2
 				}
 
 			}

--- a/Manip/patchers/TraitementFichiers.maxpat
+++ b/Manip/patchers/TraitementFichiers.maxpat
@@ -10,8 +10,8 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 42.0, 85.0, 2092.0, 1273.0 ],
-		"bglocked" : 1,
+		"rect" : [ 38.0, 81.0, 842.0, 883.0 ],
+		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
@@ -39,6 +39,272 @@
 		"subpatcher_template" : "ManipAliasingSpatial",
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-406",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2415.0, 765.0, 90.0, 34.0 ],
+					"presentation_linecount" : 2,
+					"text" : "Période échantillons T3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-405",
+					"linecount" : 2,
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2460.0, 450.0, 90.0, 34.0 ],
+					"presentation_linecount" : 2,
+					"text" : "nombre échantillons T3"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-404",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2265.0, 450.0, 90.0, 20.0 ],
+					"text" : "durée stimulus"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-402",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2415.0, 735.0, 165.0, 22.0 ],
+					"text" : "12.034"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-400",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "float", "" ],
+					"patching_rect" : [ 2445.0, 675.0, 35.0, 22.0 ],
+					"text" : "timer"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-399",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 2445.0, 600.0, 29.5, 22.0 ],
+					"text" : "+ 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-398",
+					"maxclass" : "toggle",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 2445.0, 570.0, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-396",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 2445.0, 630.0, 42.0, 22.0 ],
+					"text" : "gate 2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-395",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "bang" ],
+					"patching_rect" : [ 2415.0, 540.0, 32.0, 22.0 ],
+					"text" : "t b b"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-386",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2355.0, 450.0, 50.0, 22.0 ],
+					"text" : "2429."
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-384",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "float", "" ],
+					"patching_rect" : [ 2370.0, 390.0, 35.0, 22.0 ],
+					"text" : "timer"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-381",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2552.0, 285.0, 59.0, 22.0 ],
+					"text" : "r endPlay"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-379",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "bang", "bang", "int" ],
+					"patching_rect" : [ 2490.0, 314.0, 42.0, 22.0 ],
+					"text" : "t b b 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-380",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2490.0, 285.0, 49.0, 22.0 ],
+					"text" : "r pause"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-378",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2432.0, 331.0, 32.0, 22.0 ],
+					"text" : "gate"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-377",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "bang", "int", "int" ],
+					"patching_rect" : [ 2329.5, 326.0, 42.0, 22.0 ],
+					"text" : "t b 1 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-374",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2329.5, 297.0, 62.0, 22.0 ],
+					"text" : "r playStim"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-370",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2415.0, 450.0, 50.0, 22.0 ],
+					"text" : "153"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-368",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2445.0, 401.0, 47.0, 22.0 ],
+					"text" : "v count"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-367",
+					"maxclass" : "button",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 2445.0, 295.0, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-330",
+					"maxclass" : "newobj",
+					"numinlets" : 5,
+					"numoutlets" : 4,
+					"outlettype" : [ "int", "", "", "int" ],
+					"patching_rect" : [ 2445.0, 366.0, 61.0, 22.0 ],
+					"text" : "counter"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.109078, 0.481945, 0.537541, 1.0 ],
+					"id" : "obj-314",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 2445.0, 255.0, 89.0, 22.0 ],
+					"text" : "r centeredQuat"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-343",
 					"maxclass" : "newobj",
@@ -1277,8 +1543,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1785.0, 375.0, 87.0, 119.0 ],
-					"text" : "\"C:/Users/Gauthier/Documents/Max 8/Projects/Manip-Aliasing-Spatial/Manip/data/Reponses.txt\""
+					"patching_rect" : [ 1785.0, 375.0, 95.0, 119.0 ],
+					"text" : "\"C:/Users/User/Documents/Max 8/Projects/Manip Aliasing Spatial/Manip-Aliasing-Spatial/Manip/data/Reponses.txt\""
 				}
 
 			}
@@ -2936,7 +3202,6 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-84",
-									"int" : 1,
 									"maxclass" : "gswitch",
 									"numinlets" : 3,
 									"numoutlets" : 1,
@@ -5409,8 +5674,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 135.0, 330.0, 94.0, 91.0 ],
-					"text" : "\"C:/Users/Gauthier/Documents/Max 8/Projects/Manip-Aliasing-Spatial/Manip/data/\""
+					"patching_rect" : [ 135.0, 330.0, 126.0, 91.0 ],
+					"text" : "\"C:/Users/User/Documents/Max 8/Projects/Manip Aliasing Spatial/Manip-Aliasing-Spatial/Manip/data/\""
 				}
 
 			}
@@ -6077,6 +6342,37 @@
 					"patching_rect" : [ 30.0, 165.0, 67.0, 22.0 ],
 					"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"background" : 1,
+					"id" : "obj-391",
+					"maxclass" : "comment",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2205.0, 210.0, 195.0, 20.0 ],
+					"suppressinlet" : 1,
+					"text" : "Exporte la rotation du HeadTracker"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"angle" : 270.0,
+					"background" : 1,
+					"bgcolor" : [ 0.384313725490196, 0.556862745098039, 0.564705882352941, 1.0 ],
+					"border" : 1,
+					"bordercolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+					"id" : "obj-392",
+					"maxclass" : "panel",
+					"mode" : 0,
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 2205.0, 210.0, 420.0, 960.0 ],
+					"proportion" : 0.5,
+					"prototypename" : "backgroundPanel"
 				}
 
 			}
@@ -8234,6 +8530,22 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-367", 0 ],
+					"order" : 0,
+					"source" : [ "obj-314", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-395", 0 ],
+					"order" : 1,
+					"source" : [ "obj-314", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-318", 0 ],
 					"source" : [ "obj-315", 0 ]
 				}
@@ -8315,6 +8627,13 @@
 					"destination" : [ "obj-325", 0 ],
 					"order" : 1,
 					"source" : [ "obj-326", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-368", 0 ],
+					"source" : [ "obj-330", 0 ]
 				}
 
 			}
@@ -8477,6 +8796,20 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-378", 1 ],
+					"source" : [ "obj-367", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-370", 1 ],
+					"source" : [ "obj-368", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-80", 0 ],
 					"source" : [ "obj-37", 0 ]
 				}
@@ -8491,8 +8824,85 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-377", 0 ],
+					"source" : [ "obj-374", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-330", 2 ],
+					"source" : [ "obj-377", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-378", 0 ],
+					"source" : [ "obj-377", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-384", 0 ],
+					"source" : [ "obj-377", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-330", 0 ],
+					"source" : [ "obj-378", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-368", 0 ],
+					"source" : [ "obj-379", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-378", 0 ],
+					"source" : [ "obj-379", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-384", 1 ],
+					"source" : [ "obj-379", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-41", 0 ],
 					"source" : [ "obj-38", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-380", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-379", 0 ],
+					"source" : [ "obj-381", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-386", 1 ],
+					"source" : [ "obj-384", 0 ]
 				}
 
 			}
@@ -8509,6 +8919,48 @@
 					"destination" : [ "obj-40", 0 ],
 					"order" : 1,
 					"source" : [ "obj-39", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-396", 1 ],
+					"source" : [ "obj-395", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-398", 0 ],
+					"source" : [ "obj-395", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-400", 1 ],
+					"source" : [ "obj-396", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-400", 0 ],
+					"source" : [ "obj-396", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-399", 0 ],
+					"source" : [ "obj-398", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-396", 0 ],
+					"source" : [ "obj-399", 0 ]
 				}
 
 			}
@@ -8546,6 +8998,13 @@
 					"destination" : [ "obj-70", 0 ],
 					"order" : 0,
 					"source" : [ "obj-40", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-402", 1 ],
+					"source" : [ "obj-400", 0 ]
 				}
 
 			}

--- a/Manip/rotationTete/.gitignore
+++ b/Manip/rotationTete/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
L'orientation de la tête est sauvegardée dans le fichier `rotationTete\userName.txt`

À chaque essai, l'orientation de la tête est capturée chaque 20 ms et concaténée sur la ligne correspondant à l'essai dans le fichier.

Chaque ligne débute par le niveau de chaque variable pour l'essai en cours.

L'orientation est exportée sous forme de quaternions, séparés par des virgules.

Les stimuli A, B et C sont séparés par une valeur `next`.

Exemple de ligne :
`noise controlroom GaussLegendre 6cm noeq 7, Q0, Q1, Q2, ..., Q250, next, Q0, Q1, Q2, ..., Q250, next, Q0, Q1, Q2, ..., Q250,`

closes #40 